### PR TITLE
PRL6282 - Changing test structure

### DIFF
--- a/e2e/journeys/manageCases/createCase/C100.ts
+++ b/e2e/journeys/manageCases/createCase/C100.ts
@@ -5,39 +5,49 @@ import { C100HearingUrgency } from "./C100HearingUrgency/C100HearingUrgency";
 import { C100ApplicantDetails } from "./C100ApplicantDetails/c100ApplicantDetails";
 import { ApplicantGender } from "../../../pages/manageCases/createCase/C100/applicantDetails/applicantDetails1Page";
 
+interface c100Options {
+  page: Page;
+  user: UserRole;
+  accessibilityTest: boolean;
+  errorMessaging: boolean;
+  yesNoHearingUrgency: boolean;
+  yesNoApplicantDetails: boolean;
+  applicantGender: ApplicantGender;
+}
+
 export class C100 {
-  public static async c100(
-    page: Page,
-    user: UserRole,
-    accessibilityTest: boolean,
-    errorMessaging: boolean,
-    yesNo: boolean,
-    yesNoApplicantDetails: boolean,
-    applicantGender: ApplicantGender,
-  ): Promise<void> {
-    await SolicitorCreateInitial.createInitialCase(
-      page,
-      user,
-      false,
-      "C100",
-      false,
-    );
-    await C100HearingUrgency.c100HearingUrgency(
-      page,
-      user,
-      accessibilityTest,
-      errorMessaging,
-      yesNo,
-      false,
-    );
-    await C100ApplicantDetails.C100ApplicantDetails(
-      page,
-      user,
-      accessibilityTest,
-      errorMessaging,
-      yesNoApplicantDetails,
-      applicantGender,
-      false,
-    );
+  public static async c100({
+    page,
+    user,
+    accessibilityTest,
+    errorMessaging,
+    yesNoHearingUrgency,
+    yesNoApplicantDetails,
+    applicantGender,
+  }: c100Options): Promise<void> {
+    await SolicitorCreateInitial.createInitialCase({
+      page: page,
+      user: user,
+      accessibilityTest: false,
+      solicitorCaseType: "C100",
+      errorMessaging: false,
+    });
+    await C100HearingUrgency.c100HearingUrgency({
+      page: page,
+      user: user,
+      accessibilityTest: accessibilityTest,
+      errorMessaging: errorMessaging,
+      yesNoHearingUrgency: yesNoHearingUrgency,
+      subJourney: false,
+    });
+    await C100ApplicantDetails.C100ApplicantDetails({
+      page: page,
+      user: user,
+      accessibilityTest: accessibilityTest,
+      errorMessaging: errorMessaging,
+      yesNoApplicantDetails: yesNoApplicantDetails,
+      applicantGender: applicantGender,
+      subJourney: false,
+    });
   }
 }

--- a/e2e/journeys/manageCases/createCase/C100ApplicantDetails/c100ApplicantDetails.ts
+++ b/e2e/journeys/manageCases/createCase/C100ApplicantDetails/c100ApplicantDetails.ts
@@ -9,24 +9,34 @@ import { ApplicantDetailsSubmitPage } from "../../../../pages/manageCases/create
 import { C100TasksTabPage } from "../../../../pages/manageCases/caseTabs/c100TasksTabPage";
 import { SolicitorCreateInitial } from "../solicitorCreateInitial";
 
+interface c100ApplicantDetailsOptions {
+  page: Page;
+  user: UserRole;
+  accessibilityTest: boolean;
+  errorMessaging: boolean;
+  yesNoApplicantDetails: boolean;
+  applicantGender: ApplicantGender;
+  subJourney: boolean;
+}
+
 export class C100ApplicantDetails {
-  public static async C100ApplicantDetails(
-    page: Page,
-    user: UserRole,
-    accessibilityTest: boolean,
-    errorMessaging: boolean,
-    yesNoApplicantDetails: boolean,
-    applicantGender: ApplicantGender,
-    subJourney: boolean,
-  ): Promise<void> {
+  public static async C100ApplicantDetails({
+    page,
+    user,
+    accessibilityTest,
+    errorMessaging,
+    yesNoApplicantDetails,
+    applicantGender,
+    subJourney,
+  }: c100ApplicantDetailsOptions): Promise<void> {
     if (subJourney) {
-      await SolicitorCreateInitial.createInitialCase(
-        page,
-        user,
-        false,
-        "C100",
-        false,
-      );
+      await SolicitorCreateInitial.createInitialCase({
+        page: page,
+        user: user,
+        accessibilityTest: false,
+        solicitorCaseType: "C100",
+        errorMessaging: false,
+      });
     }
     await Helpers.selectSolicitorEvent(page, "Applicant details");
     await ApplicantDetails1Page.applicantDetails1Page(

--- a/e2e/journeys/manageCases/createCase/C100HearingUrgency/C100HearingUrgency.ts
+++ b/e2e/journeys/manageCases/createCase/C100HearingUrgency/C100HearingUrgency.ts
@@ -6,35 +6,44 @@ import { C100HearingUrgencySubmitPage } from "../../../../pages/manageCases/crea
 import { C100TasksTabPage } from "../../../../pages/manageCases/caseTabs/c100TasksTabPage";
 import { SolicitorCreateInitial } from "../solicitorCreateInitial";
 
+interface c100HearingUrgencyOptions {
+  page: Page;
+  user: UserRole;
+  accessibilityTest: boolean;
+  errorMessaging: boolean;
+  yesNoHearingUrgency: boolean;
+  subJourney: boolean;
+}
+
 export class C100HearingUrgency {
-  public static async c100HearingUrgency(
-    page: Page,
-    user: UserRole,
-    accessibilityTest: boolean,
-    errorMessaging: boolean,
-    yesNo: boolean,
-    subJourney: boolean,
-  ): Promise<void> {
+  public static async c100HearingUrgency({
+    page,
+    user,
+    accessibilityTest,
+    errorMessaging,
+    yesNoHearingUrgency,
+    subJourney,
+  }: c100HearingUrgencyOptions): Promise<void> {
     if (subJourney) {
-      await SolicitorCreateInitial.createInitialCase(
-        page,
-        user,
-        false,
-        "C100",
-        false,
-      );
+      await SolicitorCreateInitial.createInitialCase({
+        page: page,
+        user: user,
+        accessibilityTest: false,
+        solicitorCaseType: "C100",
+        errorMessaging: false,
+      });
     }
     await Helpers.selectSolicitorEvent(page, "Hearing urgency");
     await HearingUrgency1Page.hearingUrgency1Page(
       page,
       accessibilityTest,
       errorMessaging,
-      yesNo,
+      yesNoHearingUrgency,
     );
     await C100HearingUrgencySubmitPage.C100HearingUrgencySubmitPage(
       page,
       accessibilityTest,
-      yesNo,
+      yesNoHearingUrgency,
     );
     await C100TasksTabPage.c100TasksTabPage(page, accessibilityTest);
   }

--- a/e2e/journeys/manageCases/createCase/FL401.ts
+++ b/e2e/journeys/manageCases/createCase/FL401.ts
@@ -4,35 +4,44 @@ import { FL401TypeOfApplication } from "./FL401TypeOfApplication/FL401TypeOfAppl
 import { SolicitorCreateInitial } from "./solicitorCreateInitial";
 import { FL401RespondentDetails } from "./FL401RespondentDetails/FL401RespondentDetails";
 
+interface fl401Options {
+  page: Page;
+  user: UserRole;
+  accessibilityTest: boolean;
+  errorMessaging: boolean;
+  isLinkedToC100: boolean;
+  respondentDetailsAllOptionsYes: boolean;
+}
+
 export class FL401 {
-  public static async fl401(
-    page: Page,
-    user: UserRole,
-    accessibilityTest: boolean,
-    errorMessaging: boolean,
-    isLinkedToC100: boolean,
-    respondentDetailsAllOptionsYes: boolean,
-  ): Promise<void> {
-    await SolicitorCreateInitial.createInitialCase(
-      page,
-      user,
-      accessibilityTest,
-      "FL401",
-      errorMessaging,
-    );
-    await FL401TypeOfApplication.fl401TypeOfApplication(
-      page,
-      accessibilityTest,
-      errorMessaging,
-      isLinkedToC100,
-      false,
-    );
-    await FL401RespondentDetails.fl401RespondentDetails(
-      page,
-      accessibilityTest,
-      errorMessaging,
-      respondentDetailsAllOptionsYes,
-      false,
-    );
+  public static async fl401({
+    page,
+    user,
+    accessibilityTest,
+    errorMessaging,
+    isLinkedToC100,
+    respondentDetailsAllOptionsYes,
+  }: fl401Options): Promise<void> {
+    await SolicitorCreateInitial.createInitialCase({
+      page: page,
+      user: user,
+      accessibilityTest: false,
+      solicitorCaseType: "FL401",
+      errorMessaging: false,
+    });
+    await FL401TypeOfApplication.fl401TypeOfApplication({
+      page: page,
+      accessibilityTest: accessibilityTest,
+      errorMessaging: errorMessaging,
+      isLinkedToC100: isLinkedToC100,
+      subJourney: false,
+    });
+    await FL401RespondentDetails.fl401RespondentDetails({
+      page: page,
+      accessibilityTest: accessibilityTest,
+      errorMessaging: errorMessaging,
+      respondentDetailsAllOptionsYes: respondentDetailsAllOptionsYes,
+      subJourney: false,
+    });
   }
 }

--- a/e2e/journeys/manageCases/createCase/FL401RespondentDetails/FL401RespondentDetails.ts
+++ b/e2e/journeys/manageCases/createCase/FL401RespondentDetails/FL401RespondentDetails.ts
@@ -5,22 +5,30 @@ import { Fl401TasksTabPage } from "../../../../pages/manageCases/caseTabs/fl401T
 import { RespondentDetailsSubmitPage } from "../../../../pages/manageCases/createCase/FL401/respondentDetails/respondentDetailsSubmitPage";
 import { SolicitorCreateInitial } from "../solicitorCreateInitial";
 
+interface fl401RespondentDetailsOptions {
+  page: Page;
+  accessibilityTest: boolean;
+  errorMessaging: boolean;
+  respondentDetailsAllOptionsYes: boolean;
+  subJourney: boolean;
+}
+
 export class FL401RespondentDetails {
-  public static async fl401RespondentDetails(
-    page: Page,
-    accessibilityTest: boolean,
-    errorMessaging: boolean,
-    respondentDetailsAllOptionsYes: boolean,
-    subJourney: boolean,
-  ): Promise<void> {
+  public static async fl401RespondentDetails({
+    page,
+    accessibilityTest,
+    errorMessaging,
+    respondentDetailsAllOptionsYes,
+    subJourney,
+  }: fl401RespondentDetailsOptions): Promise<void> {
     if (subJourney) {
-      await SolicitorCreateInitial.createInitialCase(
-        page,
-        "solicitor",
-        false,
-        "FL401",
-        false,
-      );
+      await SolicitorCreateInitial.createInitialCase({
+        page: page,
+        user: "solicitor",
+        accessibilityTest: false,
+        solicitorCaseType: "FL401",
+        errorMessaging: false,
+      });
     }
     await Helpers.selectSolicitorEvent(page, "Respondent details");
     await RespondentDetailsPage.respondentDetailsPage(

--- a/e2e/journeys/manageCases/createCase/FL401TypeOfApplication/FL401TypeOfApplication.ts
+++ b/e2e/journeys/manageCases/createCase/FL401TypeOfApplication/FL401TypeOfApplication.ts
@@ -6,22 +6,30 @@ import { Page } from "@playwright/test";
 import { Fl401TasksTabPage } from "../../../../pages/manageCases/caseTabs/fl401TasksTabPage";
 import { SolicitorCreateInitial } from "../solicitorCreateInitial";
 
+interface fl401TypeOfApplicationOptions {
+  page: Page;
+  accessibilityTest: boolean;
+  errorMessaging: boolean;
+  isLinkedToC100: boolean;
+  subJourney: boolean;
+}
+
 export class FL401TypeOfApplication {
-  public static async fl401TypeOfApplication(
-    page: Page,
-    accessibilityTest: boolean,
-    errorMessaging: boolean,
-    isLinkedToC100: boolean,
-    subJourney: boolean,
-  ): Promise<void> {
+  public static async fl401TypeOfApplication({
+    page,
+    accessibilityTest,
+    errorMessaging,
+    isLinkedToC100,
+    subJourney,
+  }: fl401TypeOfApplicationOptions): Promise<void> {
     if (subJourney) {
-      await SolicitorCreateInitial.createInitialCase(
-        page,
-        "solicitor",
-        false,
-        "FL401",
-        false,
-      );
+      await SolicitorCreateInitial.createInitialCase({
+        page: page,
+        user: "solicitor",
+        accessibilityTest: false,
+        solicitorCaseType: "FL401",
+        errorMessaging: false,
+      });
     }
     await Helpers.selectSolicitorEvent(page, "Type of application");
     await TypeOfApplication1Page.typeOfApplication1Page(

--- a/e2e/journeys/manageCases/createCase/solicitorCreateInitial.ts
+++ b/e2e/journeys/manageCases/createCase/solicitorCreateInitial.ts
@@ -13,13 +13,19 @@ import { Fl401TasksTabPage } from "../../../pages/manageCases/caseTabs/fl401Task
 import { C100TasksTabPage } from "../../../pages/manageCases/caseTabs/c100TasksTabPage";
 
 export class SolicitorCreateInitial {
-  public static async createInitialCase(
-    page: Page,
-    user: UserRole,
-    accessibilityTest: boolean,
-    solicitorCaseType: solicitorCaseCreateType,
-    errorMessaging: boolean,
-  ): Promise<void> {
+  public static async createInitialCase({
+    page,
+    user,
+    accessibilityTest,
+    solicitorCaseType,
+    errorMessaging,
+  }: {
+    page: Page;
+    user: UserRole;
+    accessibilityTest: boolean;
+    solicitorCaseType: solicitorCaseCreateType;
+    errorMessaging: boolean;
+  }): Promise<void> {
     let caseName: string;
     await CaseList.caseList(page, user, false);
     await CaseListPage.startCreateCaseEvent(page);

--- a/e2e/pages/manageCases/createCase/C100/hearingUrgency/c100HearingUrgencySubmitPage.ts
+++ b/e2e/pages/manageCases/createCase/C100/hearingUrgency/c100HearingUrgencySubmitPage.ts
@@ -9,11 +9,11 @@ export class C100HearingUrgencySubmitPage {
   public static async C100HearingUrgencySubmitPage(
     page: Page,
     accessibilityTest: boolean,
-    yesNo: boolean,
+    yesNoHearingUrgency: boolean,
   ): Promise<void> {
     await Promise.all([
-      this.checkPageLoads(page, accessibilityTest, yesNo),
-      this.checkFilledFields(page, yesNo),
+      this.checkPageLoads(page, accessibilityTest, yesNoHearingUrgency),
+      this.checkFilledFields(page, yesNoHearingUrgency),
     ]);
     await this.continue(page);
   }
@@ -21,12 +21,12 @@ export class C100HearingUrgencySubmitPage {
   private static async checkPageLoads(
     page: Page,
     accessibilityTest: boolean,
-    yesNo: boolean,
+    yesNoHearingUrgency: boolean,
   ): Promise<void> {
     await page.waitForSelector(
       `${Selectors.h2}:text-is("${HearingUrgencySubmitContent.pageSubTitle}")`,
     );
-    let changeAbleFields: number = yesNo ? 8 : 4;
+    let changeAbleFields: number = yesNoHearingUrgency ? 8 : 4;
     await Promise.all([
       Helpers.checkGroup(
         page,
@@ -53,15 +53,15 @@ export class C100HearingUrgencySubmitPage {
 
   private static async checkFilledFields(
     page: Page,
-    yesNo: boolean,
+    yesNoHearingUrgency: boolean,
   ): Promise<void> {
-    let yesOrNo: string = yesNo ? "Yes" : "No";
+    let yesOrNo: string = yesNoHearingUrgency ? "Yes" : "No";
     await Helpers.checkVisibleAndPresent(
       page,
       `${Selectors.GovukText16}:text-is("${yesOrNo}")`,
       4,
     );
-    if (yesNo) {
+    if (yesNoHearingUrgency) {
       await Helpers.checkVisibleAndPresent(
         page,
         `${Selectors.Span}:text-is("${HearingUrgency1Content.loremIpsum}")`,

--- a/e2e/pages/manageCases/createCase/C100/hearingUrgency/hearingUrgency1Page.ts
+++ b/e2e/pages/manageCases/createCase/C100/hearingUrgency/hearingUrgency1Page.ts
@@ -24,13 +24,13 @@ export class HearingUrgency1Page {
     page: Page,
     accessibilityTest: boolean,
     errorMessaging: boolean,
-    yesNo: boolean,
+    yesNoHearingUrgency: boolean,
   ): Promise<void> {
     await this.checkPageLoads(page, accessibilityTest);
     if (errorMessaging) {
       await this.checkErrorMessaging(page);
     }
-    await this.fillInFields(page, yesNo);
+    await this.fillInFields(page, yesNoHearingUrgency);
   }
 
   private static async checkPageLoads(
@@ -175,8 +175,11 @@ export class HearingUrgency1Page {
     ]);
   }
 
-  private static async fillInFields(page: Page, yesNo: boolean): Promise<void> {
-    if (yesNo) {
+  private static async fillInFields(
+    page: Page,
+    yesNoHearingUrgency: boolean,
+  ): Promise<void> {
+    if (yesNoHearingUrgency) {
       await page.click(`${pageFields.caseUrgentYes}`);
       await page.fill(
         `${pageFields.caseUrgencyTimeAndReason}`,

--- a/e2e/tests/manageCases/createCase/C100/c100ApplicantDetails.spec.ts
+++ b/e2e/tests/manageCases/createCase/C100/c100ApplicantDetails.spec.ts
@@ -9,15 +9,15 @@ test.describe("C100 Create case applicant details tests @manageCases", (): void 
   Setting the applicant Gender to male. @crossbrowserManageCases`, async ({
     page,
   }): Promise<void> => {
-    await C100ApplicantDetails.C100ApplicantDetails(
+    await C100ApplicantDetails.C100ApplicantDetails({
       page,
-      "solicitor",
-      false,
-      false,
-      true,
-      "male",
-      true,
-    );
+      user: "solicitor",
+      accessibilityTest: false,
+      errorMessaging: false,
+      yesNoApplicantDetails: true,
+      applicantGender: "male",
+      subJourney: true,
+    });
   });
 
   test(`Complete the C100 applicant details event as a solicitor with the following options:
@@ -25,33 +25,33 @@ test.describe("C100 Create case applicant details tests @manageCases", (): void 
   Not Error message testing,
   Saying no to all options,
   Setting the applicant Gender to female.`, async ({ page }): Promise<void> => {
-    await C100ApplicantDetails.C100ApplicantDetails(
+    await C100ApplicantDetails.C100ApplicantDetails({
       page,
-      "solicitor",
-      false,
-      false,
-      false,
-      "female",
-      true,
-    );
+      user: "solicitor",
+      accessibilityTest: false,
+      errorMessaging: false,
+      yesNoApplicantDetails: false,
+      applicantGender: "female",
+      subJourney: true,
+    });
   });
 
   test(`Complete the C100 applicant details event as a solicitor with the following options:
   Not Accessibility testing,
   Error message testing,
   Saying yes to all options,
-  Setting the applicant Gender to other. @crossbrowserManageCases`, async ({
+  Setting the applicant Gender to male. @crossbrowserManageCases`, async ({
     page,
   }): Promise<void> => {
-    await C100ApplicantDetails.C100ApplicantDetails(
+    await C100ApplicantDetails.C100ApplicantDetails({
       page,
-      "solicitor",
-      false,
-      false,
-      false,
-      "female",
-      true,
-    );
+      user: "solicitor",
+      accessibilityTest: false,
+      errorMessaging: true,
+      yesNoApplicantDetails: false,
+      applicantGender: "male",
+      subJourney: true,
+    });
   });
 });
 
@@ -59,16 +59,16 @@ test(`Accessibility test the C100 applicant details event as a solicitor with th
   Accessibility testing,
   Not Error message testing,
   Saying yes to all options,
-  Setting the applicant Gender to male. @accessibilityManageCases`, async ({
+  Setting the applicant Gender to female. @accessibilityManageCases`, async ({
   page,
 }): Promise<void> => {
-  await C100ApplicantDetails.C100ApplicantDetails(
+  await C100ApplicantDetails.C100ApplicantDetails({
     page,
-    "solicitor",
-    true,
-    false,
-    false,
-    "male",
-    true,
-  );
+    user: "solicitor",
+    accessibilityTest: true,
+    errorMessaging: false,
+    yesNoApplicantDetails: false,
+    applicantGender: "female",
+    subJourney: true,
+  });
 });

--- a/e2e/tests/manageCases/createCase/C100/c100HearingUrgency.spec.ts
+++ b/e2e/tests/manageCases/createCase/C100/c100HearingUrgency.spec.ts
@@ -8,28 +8,28 @@ test.describe("C100 Create case hearing urgency tests @manageCases", (): void =>
   Saying yes to all options, @crossbrowserManageCases`, async ({
     page,
   }): Promise<void> => {
-    await C100HearingUrgency.c100HearingUrgency(
+    await C100HearingUrgency.c100HearingUrgency({
       page,
-      "solicitor",
-      false,
-      false,
-      true,
-      true,
-    );
+      user: "solicitor",
+      accessibilityTest: false,
+      errorMessaging: false,
+      yesNoHearingUrgency: true,
+      subJourney: true,
+    });
   });
 
   test(`Complete the C100 hearing urgency event as a solicitor with the following options:
   Not Accessibility testing,
   Not Error message testing,
   Saying no to all options,`, async ({ page }): Promise<void> => {
-    await C100HearingUrgency.c100HearingUrgency(
+    await C100HearingUrgency.c100HearingUrgency({
       page,
-      "solicitor",
-      false,
-      false,
-      false,
-      true,
-    );
+      user: "solicitor",
+      accessibilityTest: false,
+      errorMessaging: false,
+      yesNoHearingUrgency: false,
+      subJourney: true,
+    });
   });
 
   test(`Complete the C100 hearing urgency event as a solicitor with the following options:
@@ -38,14 +38,14 @@ test.describe("C100 Create case hearing urgency tests @manageCases", (): void =>
   Saying yes to all options, @crossbrowserManageCases`, async ({
     page,
   }): Promise<void> => {
-    await C100HearingUrgency.c100HearingUrgency(
+    await C100HearingUrgency.c100HearingUrgency({
       page,
-      "solicitor",
-      false,
-      true,
-      false,
-      true,
-    );
+      user: "solicitor",
+      accessibilityTest: false,
+      errorMessaging: true,
+      yesNoHearingUrgency: true,
+      subJourney: true,
+    });
   });
 });
 
@@ -55,12 +55,12 @@ test(`Accessibility test the C100 hearing urgency event as a solicitor with the 
   Saying yes to all options, @accessibilityManageCases`, async ({
   page,
 }): Promise<void> => {
-  await C100HearingUrgency.c100HearingUrgency(
+  await C100HearingUrgency.c100HearingUrgency({
     page,
-    "solicitor",
-    true,
-    false,
-    true,
-    true,
-  );
+    user: "solicitor",
+    accessibilityTest: true,
+    errorMessaging: false,
+    yesNoHearingUrgency: true,
+    subJourney: true,
+  });
 });

--- a/e2e/tests/manageCases/createCase/FL401/fl401RespondentDetails.spec.ts
+++ b/e2e/tests/manageCases/createCase/FL401/fl401RespondentDetails.spec.ts
@@ -8,26 +8,26 @@ test.describe("FL401 Create case respondent details tests @manageCases", (): voi
   Saying yes to all options, @crossbrowserManageCases`, async ({
     page,
   }): Promise<void> => {
-    await FL401RespondentDetails.fl401RespondentDetails(
-      page,
-      false,
-      false,
-      true,
-      true,
-    );
+    await FL401RespondentDetails.fl401RespondentDetails({
+      page: page,
+      accessibilityTest: false,
+      errorMessaging: false,
+      respondentDetailsAllOptionsYes: true,
+      subJourney: true,
+    });
   });
 
   test(`Complete the FL401 respondent details event as a solicitor with the following options:
   Not Accessibility testing,
   Not Error message testing,
   Saying no to all options,`, async ({ page }): Promise<void> => {
-    await FL401RespondentDetails.fl401RespondentDetails(
-      page,
-      false,
-      false,
-      false,
-      true,
-    );
+    await FL401RespondentDetails.fl401RespondentDetails({
+      page: page,
+      accessibilityTest: false,
+      errorMessaging: false,
+      respondentDetailsAllOptionsYes: false,
+      subJourney: true,
+    });
   });
 
   test(`Complete the FL401 respondent details event as a solicitor with the following options:
@@ -36,13 +36,13 @@ test.describe("FL401 Create case respondent details tests @manageCases", (): voi
   Saying yes to all options, @crossbrowserManageCases`, async ({
     page,
   }): Promise<void> => {
-    await FL401RespondentDetails.fl401RespondentDetails(
-      page,
-      false,
-      true,
-      true,
-      true,
-    );
+    await FL401RespondentDetails.fl401RespondentDetails({
+      page: page,
+      accessibilityTest: false,
+      errorMessaging: true,
+      respondentDetailsAllOptionsYes: true,
+      subJourney: true,
+    });
   });
 });
 
@@ -52,11 +52,11 @@ test(`Accessibility test the FL401 respondent details event as a solicitor with 
   Saying yes to all options, @accessibilityManageCases`, async ({
   page,
 }): Promise<void> => {
-  await FL401RespondentDetails.fl401RespondentDetails(
-    page,
-    true,
-    false,
-    true,
-    true,
-  );
+  await FL401RespondentDetails.fl401RespondentDetails({
+    page: page,
+    accessibilityTest: true,
+    errorMessaging: false,
+    respondentDetailsAllOptionsYes: true,
+    subJourney: true,
+  });
 });

--- a/e2e/tests/manageCases/createCase/FL401/fl401TypeOfApplication.spec.ts
+++ b/e2e/tests/manageCases/createCase/FL401/fl401TypeOfApplication.spec.ts
@@ -8,26 +8,26 @@ test.describe("FL401 Create case type of application tests @manageCases", (): vo
   Saying yes to linked to C100, @crossbrowserManageCases`, async ({
     page,
   }): Promise<void> => {
-    await FL401TypeOfApplication.fl401TypeOfApplication(
-      page,
-      false,
-      false,
-      true,
-      true,
-    );
+    await FL401TypeOfApplication.fl401TypeOfApplication({
+      page: page,
+      accessibilityTest: false,
+      errorMessaging: false,
+      isLinkedToC100: true,
+      subJourney: true,
+    });
   });
 
   test(`Complete the FL401 type of application event as a solicitor with the following options:
   Not Accessibility testing,
   Not Error message testing,
   Saying no to linked to C100,`, async ({ page }): Promise<void> => {
-    await FL401TypeOfApplication.fl401TypeOfApplication(
-      page,
-      false,
-      false,
-      false,
-      true,
-    );
+    await FL401TypeOfApplication.fl401TypeOfApplication({
+      page: page,
+      accessibilityTest: false,
+      errorMessaging: false,
+      isLinkedToC100: false,
+      subJourney: true,
+    });
   });
 
   test(`Complete the FL401 type of application event as a solicitor with the following options:
@@ -36,13 +36,13 @@ test.describe("FL401 Create case type of application tests @manageCases", (): vo
   Saying yes to linked to C100, @crossbrowserManageCases`, async ({
     page,
   }): Promise<void> => {
-    await FL401TypeOfApplication.fl401TypeOfApplication(
-      page,
-      false,
-      true,
-      true,
-      true,
-    );
+    await FL401TypeOfApplication.fl401TypeOfApplication({
+      page: page,
+      accessibilityTest: false,
+      errorMessaging: true,
+      isLinkedToC100: true,
+      subJourney: true,
+    });
   });
 });
 
@@ -52,11 +52,11 @@ test(`Accessibility test the FL401 type of application event as a solicitor with
   Saying yes to linked to C100, @accessibilityManageCases`, async ({
   page,
 }): Promise<void> => {
-  await FL401TypeOfApplication.fl401TypeOfApplication(
-    page,
-    true,
-    false,
-    true,
-    true,
-  );
+  await FL401TypeOfApplication.fl401TypeOfApplication({
+    page: page,
+    accessibilityTest: true,
+    errorMessaging: false,
+    isLinkedToC100: true,
+    subJourney: true,
+  });
 });

--- a/e2e/tests/manageCases/createCase/createCase.spec.ts
+++ b/e2e/tests/manageCases/createCase/createCase.spec.ts
@@ -10,7 +10,15 @@ test.describe("Manage cases case solicitor create case tests. @manageCases", ():
   Saying yes to all applicant details questions with a male applicant @crossbrowserManageCases`, async ({
     page,
   }): Promise<void> => {
-    await C100.c100(page, "solicitor", false, false, true, true, "male");
+    await C100.c100({
+      page: page,
+      user: "solicitor",
+      accessibilityTest: false,
+      errorMessaging: false,
+      yesNoHearingUrgency: true,
+      yesNoApplicantDetails: true,
+      applicantGender: "male",
+    });
   });
 
   test(`Complete the C100 create case event as a solicitor with the following options:
@@ -20,7 +28,15 @@ test.describe("Manage cases case solicitor create case tests. @manageCases", ():
   Saying no to all applicant details questions with a female applicant @crossbrowserManageCases`, async ({
     page,
   }): Promise<void> => {
-    await C100.c100(page, "solicitor", false, false, false, false, "female");
+    await C100.c100({
+      page: page,
+      user: "solicitor",
+      accessibilityTest: false,
+      errorMessaging: false,
+      yesNoHearingUrgency: false,
+      yesNoApplicantDetails: false,
+      applicantGender: "male",
+    });
   });
 
   test(`Complete the FL401 create case event as a solicitor with the following options:
@@ -30,7 +46,14 @@ test.describe("Manage cases case solicitor create case tests. @manageCases", ():
   Saying yes to all Type of application questions @crossbrowserManageCases`, async ({
     page,
   }): Promise<void> => {
-    await FL401.fl401(page, "solicitor", false, false, true, true);
+    await FL401.fl401({
+      page: page,
+      user: "solicitor",
+      accessibilityTest: false,
+      errorMessaging: false,
+      isLinkedToC100: true,
+      respondentDetailsAllOptionsYes: true,
+    });
   });
 
   test(`Complete the FL401 create case event as a solicitor with the following options:
@@ -40,6 +63,13 @@ test.describe("Manage cases case solicitor create case tests. @manageCases", ():
   Saying no to all Type of application questions @crossbrowserManageCases`, async ({
     page,
   }): Promise<void> => {
-    await FL401.fl401(page, "solicitor", false, false, false, false);
+    await FL401.fl401({
+      page: page,
+      user: "solicitor",
+      accessibilityTest: false,
+      errorMessaging: false,
+      isLinkedToC100: false,
+      respondentDetailsAllOptionsYes: false,
+    });
   });
 });


### PR DESCRIPTION
### Change description

The Solicitor create case event is filled with sub-events, and as such testing all permutations as a part of a single create case is a large amount of permutations with very large complexity.

**Solution:**

The following:
- Each sub event will have it's own set of tests, and corresponding test file, testing all possible permutations.
- The wider C100/FL401 event will have a single, hard coded test, to ensure that a case can be created.

### JIRA link

[PRL-6282](https://tools.hmcts.net/jira/browse/PRL-6282)

**Before merging a pull request make sure that:**

- [x] Commits are meaningful and simple
- [x] All commits are squashed into a single commit
- [x] README and other documentation has been updated / added (if needed)
