### PR TITLE
fix: Use correct error message selector for dummy payment

### DIFF
--- a/e2e/pages/manageCases/caseWorker/dummyPaymentAwp1Page.ts
+++ b/e2e/pages/manageCases/caseWorker/dummyPaymentAwp1Page.ts
@@ -85,12 +85,12 @@ export class DummyPaymentAwp1Page extends CommonPage {
       ),
       Helpers.checkVisibleAndPresent(
         page,
-        `${Selectors.ErrorMessage}:has-text("${DummyPaymentAwp1Content.errorMessagePaymentService}")`,
+        `${Selectors.GovukErrorMessage}:has-text("${DummyPaymentAwp1Content.errorMessagePaymentService}")`,
         1,
       ),
       Helpers.checkVisibleAndPresent(
         page,
-        `${Selectors.ErrorMessage}:has-text("${DummyPaymentAwp1Content.errorMessagePaymentStatus}")`,
+        `${Selectors.GovukErrorMessage}:has-text("${DummyPaymentAwp1Content.errorMessagePaymentStatus}")`,
         1,
       ),
     ]);


### PR DESCRIPTION
### Change description

Update the error message selector for the dummy payment for AWP page
