### PR TITLE
PRL-6570: add judge and casemanager to azure secrets

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -64,6 +64,10 @@ def secrets = [
     secret('idam-token-url', 'IDAM_TOKEN_URL'),
     secret('idam-citizen-password', 'IDAM_CITIZEN_USER_PASSWORD'),
     secret('idam-testing-support-users-url', 'IDAM_TESTING_SUPPORT_USERS_URL'),
+    secret('judge-testuser-one', 'JUDGE_USERNAME'),
+    secret('judge-testpassword', 'JUDGE_PASSWORD'),
+    secret('case-manager-swansea-username', 'CASEMANAGER_USERNAME'),
+    secret('case-manager-swansea-password', 'CASEMANAGER_PASSWORD'),
   ]
 ]
 

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -57,6 +57,10 @@ def secrets = [
     secret('idam-token-url', 'IDAM_TOKEN_URL'),
     secret('idam-citizen-password', 'IDAM_CITIZEN_USER_PASSWORD'),
     secret('idam-testing-support-users-url', 'IDAM_TESTING_SUPPORT_USERS_URL'),
+    secret('judge-testuser-one', 'JUDGE_USERNAME'),
+    secret('judge-testpassword', 'JUDGE_PASSWORD'),
+    secret('case-manager-swansea-username', 'CASEMANAGER_USERNAME'),
+    secret('case-manager-swansea-password', 'CASEMANAGER_PASSWORD'),
   ]
 ]
 


### PR DESCRIPTION
[PRL-6570](https://tools.hmcts.net/jira/browse/PRL-6570): adding judge and casemanager to azure secrets and mapping
