### PR TITLE
globel setup update

### DIFF
--- a/e2e/tests/global.setup.ts
+++ b/e2e/tests/global.setup.ts
@@ -1,21 +1,49 @@
-import { APIRequestContext, request, test as setup } from "@playwright/test";
+import {
+  APIRequestContext,
+  Page,
+  request,
+  test as setup,
+} from "@playwright/test";
 import IdamLoginHelper from "../common/idamLoginHelper";
 import config from "../config";
 import { getAccessToken } from "../common/getAccessTokenHelper";
+import { existsSync } from "fs";
 
-setup("Setup solicitor user", async ({ page }) => {
+async function setupSolicitorUser(page: Page) {
   await IdamLoginHelper.signInSolicitorUser(
     page,
     "solicitor",
     config.manageCasesBaseURL,
   );
-});
+}
 
-setup("Retrieve bearer token for citizen user creation", async () => {
+async function setupCitizenUserToken() {
   const apiContext: APIRequestContext = await request.newContext();
   const token = await getAccessToken("citizenCreateUser", apiContext);
   if (!token) {
     throw new Error("Setup failed: Unable to get bearer token.");
   }
   process.env.CITIZEN_CREATE_USER_BEARER_TOKEN = token;
-});
+}
+
+const isEnvFilePresent = existsSync(".env");
+const runningTest = process.env.RUNNING_TEST;
+
+if (!isEnvFilePresent) {
+  if (runningTest === "manageCases") {
+    setup("Setup solicitor user", async ({ page }) => {
+      await setupSolicitorUser(page);
+    });
+  } else if (runningTest === "citizenFrontend") {
+    setup("Retrieve bearer token for citizen user creation", async () => {
+      await setupCitizenUserToken();
+    });
+  }
+} else {
+  setup("Setup solicitor user", async ({ page }) => {
+    await setupSolicitorUser(page);
+  });
+  setup("Retrieve bearer token for citizen user creation", async () => {
+    await setupCitizenUserToken();
+  });
+}

--- a/package.json
+++ b/package.json
@@ -33,16 +33,16 @@
     "test:changes": "yarn playwright install && ts-node ./e2e/common/changedTestsRunner.ts",
     "test:fullfunctional": "echo 'This is a placeholder'",
     "test:crossbrowser": "echo 'This is a placeholder'",
-    "test:citizenSmoke": "yarn playwright install && yarn playwright test --project chromium --grep @citizenSmoke",
-    "test:manageCasesSmoke": "yarn playwright install && yarn playwright test --project chromium --grep @manageCasesSmoke",
-    "test:manageCasesChrome": "yarn playwright install && yarn playwright test --project chromium --grep @manageCases",
-    "test:manageCasesFirefox": "yarn playwright install firefox && yarn playwright test --project firefox --grep @crossbrowserManageCases",
-    "test:manageCasesSafari": "yarn playwright install webkit && yarn playwright test --project webkit --grep @crossbrowserManageCases",
-    "test:manageCasesAccessibility": "yarn playwright install && yarn playwright test --project chromium --grep @accessibilityManageCases",
-    "test:citizenFrontendChrome": "yarn playwright install && yarn playwright test --project chromium --grep @citizenFrontend",
-    "test:citizenFrontendFirefox": "yarn playwright install firefox && yarn playwright test --project firefox --grep @crossbrowserCitizenFrontend",
-    "test:citizenFrontendSafari": "yarn playwright install webkit && yarn playwright test --project webkit --grep @crossbrowserCitizenFrontend",
-    "test:citizenFrontendAccessibility": "yarn playwright install && yarn playwright test --project chromium --grep @accessibilityCitizenFrontend"
+    "test:citizenSmoke": "RUNNING_TEST=citizenFrontend yarn playwright install && yarn playwright test --project chromium --grep @citizenSmoke",
+    "test:manageCasesSmoke": "RUNNING_TEST=manageCases yarn playwright install && yarn playwright test --project chromium --grep @manageCasesSmoke",
+    "test:manageCasesChrome": "RUNNING_TEST=manageCases yarn playwright install && yarn playwright test --project chromium --grep @manageCases",
+    "test:manageCasesFirefox": "RUNNING_TEST=manageCases yarn playwright install firefox && yarn playwright test --project firefox --grep @crossbrowserManageCases",
+    "test:manageCasesSafari": "RUNNING_TEST=manageCases yarn playwright install webkit && yarn playwright test --project webkit --grep @crossbrowserManageCases",
+    "test:manageCasesAccessibility": "RUNNING_TEST=manageCases yarn playwright install && yarn playwright test --project chromium --grep @accessibilityManageCases",
+    "test:citizenFrontendChrome": "RUNNING_TEST=citizenFrontend yarn playwright install && yarn playwright test --project chromium --grep @citizenFrontend",
+    "test:citizenFrontendFirefox": "RUNNING_TEST=citizenFrontend yarn playwright install firefox && yarn playwright test --project firefox --grep @crossbrowserCitizenFrontend",
+    "test:citizenFrontendSafari": "RUNNING_TEST=citizenFrontend yarn playwright install webkit && yarn playwright test --project webkit --grep @crossbrowserCitizenFrontend",
+    "test:citizenFrontendAccessibility": "RUNNING_TEST=citizenFrontend yarn playwright install && yarn playwright test --project chromium --grep @accessibilityCitizenFrontend"
   },
   "pre-commit": [
     "lint"


### PR DESCRIPTION
changes so that only set up that is needed for the test is done (ie grab bearer token when the pipeline runs citizen tests and only set up solicitor user when manage cases is being run)