### PR TITLE
[PRL-6737]: Tests for C8 refuge details in the FL401 case tabs

### DIFF
--- a/e2e/fixtures/manageCases/caseTabs/FL401/fl401ConfidentialDetailsTabContent.ts
+++ b/e2e/fixtures/manageCases/caseTabs/FL401/fl401ConfidentialDetailsTabContent.ts
@@ -1,0 +1,16 @@
+export enum FL401ConfidentialDetailsTabContent {
+  tabName = "Confidential details",
+  applicantSection = "Applicant",
+  c8DraftDocumentSection = "C8 Document",
+  c8DraftDocumentWelshSection = "C8 Document (Welsh)",
+  refugeSection = "Refuge documents",
+  refugeSectionPartyType = "Party Type",
+  refugeSectionPartyName = "Party name",
+  refugeSectionDocumentName = "Document name",
+  refugeSectionUploadedDate = "Uploaded date",
+  refugeSectionDocument = "Document",
+  refugeSectionApplicantDetailsText161 = "Applicant 1",
+  refugeSectionApplicantDetailsText162 = "John Smith",
+  refugeSectionFile = "mockFile.pdf",
+  link = "mockFile.pdf",
+}

--- a/e2e/fixtures/manageCases/caseTabs/FL401/fl401SummaryTabContent.ts
+++ b/e2e/fixtures/manageCases/caseTabs/FL401/fl401SummaryTabContent.ts
@@ -1,0 +1,15 @@
+export enum FL401SummaryTabContent {
+  tabName = "Summary",
+  tabTitle = "Summary",
+  subTitle1 = "Allocated judge",
+  subTitle2 = "Case Status",
+  subTitle3 = "Confidential details",
+  subTitle4 = "Urgency",
+  subTitle5 = "Type of application",
+  subTitle6 = "Special arrangements",
+  subTitle7 = "Other proceedings",
+  subTitle8 = "Date submitted to HMCTS",
+  refugeSubTitle = "Refuge case",
+  refugeQuestionText16 = "Anyone living in a refuge?",
+  refugeAnswerText16 = "Yes",
+}

--- a/e2e/journeys/manageCases/caseTabs/fl401CaseTabs.ts
+++ b/e2e/journeys/manageCases/caseTabs/fl401CaseTabs.ts
@@ -1,0 +1,61 @@
+import { Browser, Page } from "@playwright/test";
+import { solicitorCaseCreateType } from "../../../common/types";
+import { DummyPaymentAwp } from "../caseWorker/dummyPayment/dummyPaymentAwp";
+import { FL401SummaryTabPage } from "../../../pages/manageCases/caseTabs/FL401/fl401SummaryTabPage";
+import { Helpers } from "../../../common/helpers";
+import Config from "../../../config";
+import { FL401ConfidentialDetailsTabPage } from "../../../pages/manageCases/caseTabs/FL401/fl401ConfidentialDetailsTabPage";
+
+interface FL401CaseTabsParams {
+  page: Page;
+  browser: Browser;
+  errorMessaging: boolean;
+  accessibilityTest: boolean;
+  paymentStatusPaid: boolean;
+  caseType: solicitorCaseCreateType;
+  applicantLivesInRefuge: boolean;
+  otherPersonLivesInRefuge: boolean;
+}
+
+export class FL401CaseTabs {
+  public static async fl401CaseTabs({
+    page,
+    browser,
+    errorMessaging,
+    accessibilityTest,
+    paymentStatusPaid,
+    caseType,
+    applicantLivesInRefuge,
+    otherPersonLivesInRefuge,
+  }: FL401CaseTabsParams): Promise<void> {
+    const caseRef = await DummyPaymentAwp.dummyPaymentAwp({
+      page: page,
+      errorMessaging: errorMessaging,
+      accessibilityTest: accessibilityTest,
+      paymentStatusPaid: paymentStatusPaid,
+      caseType: caseType,
+      applicantLivesInRefuge: applicantLivesInRefuge,
+      otherPersonLivesInRefuge: otherPersonLivesInRefuge,
+    });
+    const courtAdminPage: Page = await Helpers.openNewBrowserWindow(
+      browser,
+      "courtAdminStoke",
+    );
+    await Helpers.goToCase(
+      courtAdminPage,
+      Config.manageCasesBaseURL,
+      caseRef,
+      "Summary",
+    );
+    await FL401SummaryTabPage.fl401SummaryTabPage(
+      courtAdminPage,
+      accessibilityTest,
+      applicantLivesInRefuge,
+    );
+    await FL401ConfidentialDetailsTabPage.fl401ConfidentialDetailsTabPage(
+      courtAdminPage,
+      accessibilityTest,
+      applicantLivesInRefuge,
+    );
+  }
+}

--- a/e2e/journeys/manageCases/caseWorker/dummyPayment/dummyPaymentAwp.ts
+++ b/e2e/journeys/manageCases/caseWorker/dummyPayment/dummyPaymentAwp.ts
@@ -61,7 +61,10 @@ export class DummyPaymentAwp {
         otherPersonLivesInRefuge: otherPersonLivesInRefuge,
       });
     } else {
-      await DummyFL401.dummyFL401({ page });
+      await DummyFL401.dummyFL401({ 
+        page: page,
+        applicantLivesInRefuge: applicantLivesInRefuge,
+       });
     }
   }
 }

--- a/e2e/journeys/manageCases/createCase/dummyCase/dummyC100ApplicantDetails.ts
+++ b/e2e/journeys/manageCases/createCase/dummyCase/dummyC100ApplicantDetails.ts
@@ -3,7 +3,7 @@ import { Page } from "@playwright/test";
 import { Selectors } from "../../../../common/selectors";
 import { ApplicantDetails1Content } from "../../../../fixtures/manageCases/createCase/C100/applicantDetails/applicantDetails1Content";
 import { ApplicantDetailsSubmitContent } from "../../../../fixtures/manageCases/createCase/C100/applicantDetails/applicantDetailsSubmitContent";
-import { DummyApplicantDetailsPage } from "../../../../pages/manageCases/createCase/C100/dummyCase/dummyApplicantDetailsPage";
+import { DummyC100ApplicantDetailsPage } from "../../../../pages/manageCases/createCase/C100/dummyCase/dummyC100ApplicantDetailsPage";
 
 export class DummyC100ApplicantDetails {
   public static async dummyC100ApplicantDetails(
@@ -11,7 +11,7 @@ export class DummyC100ApplicantDetails {
     applicantLivesInRefuge: boolean,
   ): Promise<void> {
     await Helpers.selectSolicitorEvent(page, "Applicant details");
-    await DummyApplicantDetailsPage.dummyApplicantDetailsPage(
+    await DummyC100ApplicantDetailsPage.dummyApplicantDetailsPage(
       page,
       applicantLivesInRefuge,
     );

--- a/e2e/journeys/manageCases/createCase/dummyCase/dummyC100OtherPersonDetails.ts
+++ b/e2e/journeys/manageCases/createCase/dummyCase/dummyC100OtherPersonDetails.ts
@@ -3,7 +3,7 @@ import { Page } from "@playwright/test";
 import { Selectors } from "../../../../common/selectors";
 import { OtherPeopleInTheCase1Content } from "../../../../fixtures/manageCases/createCase/C100/otherPeopleInTheCaseRevised/otherPeopleInTheCaseRevised1Content.";
 import { OtherPeopleInTheCaseSubmitContent } from "../../../../fixtures/manageCases/createCase/C100/otherPeopleInTheCaseRevised/otherPeopleInTheCaseSubmitContent";
-import { DummyOtherPersonDetailsPage } from "../../../../pages/manageCases/createCase/C100/dummyCase/dummyOtherPersonDetailsPage";
+import { DummyC100OtherPersonDetailsPage } from "../../../../pages/manageCases/createCase/C100/dummyCase/dummyC100OtherPersonDetailsPage";
 
 export class DummyC100OtherPersonDetails {
   public static async dummyC100OtherPersonDetails(
@@ -11,7 +11,7 @@ export class DummyC100OtherPersonDetails {
     otherPersonLivesInRefuge: boolean,
   ): Promise<void> {
     await Helpers.selectSolicitorEvent(page, "Other people in the case");
-    await DummyOtherPersonDetailsPage.dummyOtherPersonDetailsPage(
+    await DummyC100OtherPersonDetailsPage.dummyOtherPersonDetailsPage(
       page,
       otherPersonLivesInRefuge,
     );

--- a/e2e/journeys/manageCases/createCase/dummyCase/dummyFL401.ts
+++ b/e2e/journeys/manageCases/createCase/dummyCase/dummyFL401.ts
@@ -1,17 +1,26 @@
 import { Page } from "@playwright/test";
 import { DummyCreateInitial } from "./dummyCreateInitial";
 import { Fl401StatementOfTruth } from "../FL401StatementOfTruth/fl401StatementOfTruth";
+import { DummyFL401ApplicantDetails } from "./dummyFL401ApplicantDetails";
 
 interface dummyFL401Options {
-  page: Page;
+  page: Page,
+  applicantLivesInRefuge: boolean,
 }
 
 export class DummyFL401 {
-  public static async dummyFL401({ page }: dummyFL401Options): Promise<void> {
+  public static async dummyFL401({ 
+    page,
+    applicantLivesInRefuge,
+  }: dummyFL401Options): Promise<void> {
     await DummyCreateInitial.createDummyCase({
       page: page,
       solicitorCaseType: "FL401",
     });
+    await DummyFL401ApplicantDetails.dummyFL401ApplicantDetails(
+      page,
+      applicantLivesInRefuge,
+    );
     await Fl401StatementOfTruth.fl401StatementOfTruth(
       {
         page: page,

--- a/e2e/journeys/manageCases/createCase/dummyCase/dummyFL401ApplicantDetails.ts
+++ b/e2e/journeys/manageCases/createCase/dummyCase/dummyFL401ApplicantDetails.ts
@@ -1,0 +1,25 @@
+import { Helpers } from "../../../../common/helpers";
+import { Page } from "@playwright/test";
+import { Selectors } from "../../../../common/selectors";
+import { ApplicantDetails1Content } from "../../../../fixtures/manageCases/createCase/FL401/applicantDetails/applicantDetails1Content";
+import { ApplicantDetailsSubmitContent } from "../../../../fixtures/manageCases/createCase/FL401/applicantDetails/applicantDetailsSubmitContent";
+import { DummyFL401ApplicantDetailsPage } from "../../../../pages/manageCases/createCase/FL401/dummyCase/dummyFL401ApplicantDetailsPage";
+
+export class DummyFL401ApplicantDetails {
+  public static async dummyFL401ApplicantDetails(
+    page: Page,
+    applicantLivesInRefuge: boolean,
+  ): Promise<void> {
+    await Helpers.selectSolicitorEvent(page, "Applicant details");
+    await DummyFL401ApplicantDetailsPage.dummyApplicantDetailsPage(
+      page,
+      applicantLivesInRefuge,
+    );
+    await page.click(
+      `${Selectors.button}:text-is("${ApplicantDetails1Content.continue}")`,
+    );
+    await page.click(
+      `${Selectors.button}:text-is("${ApplicantDetailsSubmitContent.saveAndContinue}")`,
+    );
+  }
+}

--- a/e2e/pages/manageCases/caseTabs/FL401/fl401ConfidentialDetailsTabPage.ts
+++ b/e2e/pages/manageCases/caseTabs/FL401/fl401ConfidentialDetailsTabPage.ts
@@ -1,0 +1,108 @@
+import { Page } from "@playwright/test";
+import { Selectors } from "../../../../common/selectors";
+import { Helpers } from "../../../../common/helpers";
+import AccessibilityTestHelper from "../../../../common/accessibilityTestHelper";
+import { FL401ConfidentialDetailsTabContent } from "../../../../fixtures/manageCases/caseTabs/FL401/fl401ConfidentialDetailsTabContent";
+
+enum UniqueSelectors {
+  refugeDocumentsSection = "td#case-viewer-field-read--refugeDocuments",
+}
+
+export class FL401ConfidentialDetailsTabPage {
+  public static async fl401ConfidentialDetailsTabPage(
+    page: Page,
+    accessibilityTest: boolean,
+    applicantLivesInRefuge: boolean,
+  ): Promise<void> {
+    await this.clickTab(page);
+    await this.checkPageLoads(
+      page,
+      accessibilityTest,
+      applicantLivesInRefuge,
+    );
+  }
+
+  private static async checkPageLoads(
+    page: Page,
+    accessibilityTest: boolean,
+    applicantLivesInRefuge: boolean,
+  ): Promise<void> {
+    await Helpers.checkVisibleAndPresent(
+      page,
+      `${Selectors.div}${Selectors.GovukText16}:text-is("${FL401ConfidentialDetailsTabContent.applicantSection}")`,
+      1,
+    );
+    await Helpers.checkVisibleAndPresent(
+      page,
+      `${Selectors.div}${Selectors.GovukText16}:text-is("${FL401ConfidentialDetailsTabContent.c8DraftDocumentSection}")`,
+      1,
+    );
+    await Helpers.checkVisibleAndPresent(
+      page,
+      `${Selectors.div}${Selectors.GovukText16}:text-is("${FL401ConfidentialDetailsTabContent.c8DraftDocumentWelshSection}")`,
+      1,
+    );
+    if (applicantLivesInRefuge) {
+      await Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.div}${Selectors.GovukText16}:text-is("${FL401ConfidentialDetailsTabContent.refugeSection}")`,
+        1,
+      );
+      await Helpers.checkVisibleAndPresent(
+        page,
+        `${UniqueSelectors.refugeDocumentsSection} ${Selectors.Span}${Selectors.GovukText16}:text-is("${FL401ConfidentialDetailsTabContent.refugeSectionPartyType}")`,
+        1,
+      );
+      await Helpers.checkVisibleAndPresent(
+        page,
+        `${UniqueSelectors.refugeDocumentsSection} ${Selectors.Span}${Selectors.GovukText16}:text-is("${FL401ConfidentialDetailsTabContent.refugeSectionPartyName}")`,
+        1,
+      );
+      await Helpers.checkVisibleAndPresent(
+        page,
+        `${UniqueSelectors.refugeDocumentsSection} ${Selectors.Span}${Selectors.GovukText16}:text-is("${FL401ConfidentialDetailsTabContent.refugeSectionDocumentName}")`,
+        1,
+      );
+      await Helpers.checkVisibleAndPresent(
+        page,
+        `${UniqueSelectors.refugeDocumentsSection} ${Selectors.Span}${Selectors.GovukText16}:text-is("${FL401ConfidentialDetailsTabContent.refugeSectionUploadedDate}")`,
+        1,
+      );
+      await Helpers.checkVisibleAndPresent(
+        page,
+        `${UniqueSelectors.refugeDocumentsSection} ${Selectors.Span}${Selectors.GovukText16}:text-is("${FL401ConfidentialDetailsTabContent.refugeSectionDocument}")`,
+        1,
+      );
+      await Helpers.checkGroup(
+        page,
+        2,
+        FL401ConfidentialDetailsTabContent,
+        "refugeSectionApplicantDetailsText16",
+        `${UniqueSelectors.refugeDocumentsSection} ${Selectors.Span}${Selectors.GovukText16}`,
+      );
+      await Helpers.checkVisibleAndPresent(
+        page,
+        `${UniqueSelectors.refugeDocumentsSection} ${Selectors.Span}${Selectors.GovukText16}:text-is("${FL401ConfidentialDetailsTabContent.refugeSectionFile}")`,
+        1,
+      );
+      await Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.a}:text-is("${FL401ConfidentialDetailsTabContent.link}")`,
+        1,
+      );
+    }
+
+    if (accessibilityTest) {
+      await AccessibilityTestHelper.run(page);
+    }
+  }
+
+  private static async clickTab(page: Page): Promise<void> {
+    await page
+      .getByRole("tab", {
+        name: FL401ConfidentialDetailsTabContent.tabName,
+        exact: true,
+      })
+      .click();
+  }
+}

--- a/e2e/pages/manageCases/caseTabs/FL401/fl401SummaryTabPage.ts
+++ b/e2e/pages/manageCases/caseTabs/FL401/fl401SummaryTabPage.ts
@@ -1,0 +1,65 @@
+import { Page } from "@playwright/test";
+import { Selectors } from "../../../../common/selectors";
+import { Helpers } from "../../../../common/helpers";
+import AccessibilityTestHelper from "../../../../common/accessibilityTestHelper";
+import { FL401SummaryTabContent } from "../../../../fixtures/manageCases/caseTabs/FL401/fl401SummaryTabContent";
+
+export class FL401SummaryTabPage {
+  public static async fl401SummaryTabPage(
+    page: Page,
+    accessibilityTest: boolean,
+    applicantLivesInRefuge: boolean,
+  ): Promise<void> {
+    await this.clickTab(page);
+    await this.checkPageLoads(
+      page,
+      accessibilityTest,
+      applicantLivesInRefuge,
+    );
+  }
+
+  private static async checkPageLoads(
+    page: Page,
+    accessibilityTest: boolean,
+    applicantLivesInRefuge: boolean,
+  ): Promise<void> {
+    await page.waitForSelector(
+      `${Selectors.h1}:text-is("${FL401SummaryTabContent.tabTitle}")`,
+    );
+    if (applicantLivesInRefuge) {
+      await Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.h2}:text-is("${FL401SummaryTabContent.refugeSubTitle}")`,
+        1,
+      );
+      await Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukText16}:text-is("${FL401SummaryTabContent.refugeQuestionText16}")`,
+        2,
+      );
+    } else {
+      await page.waitForSelector(
+        `${Selectors.h2}:text-is("${FL401SummaryTabContent.refugeSubTitle}")`,
+        { state: "hidden" },
+      );
+    }
+    await Promise.all([
+      await Helpers.checkGroup(
+        page,
+        8,
+        FL401SummaryTabContent,
+        "subTitle",
+        `${Selectors.h2}`,
+      ),
+    ]);
+    if (accessibilityTest) {
+      await AccessibilityTestHelper.run(page);
+    }
+  }
+
+  private static async clickTab(page: Page): Promise<void> {
+    await page
+      .getByRole("tab", { name: FL401SummaryTabContent.tabName, exact: true })
+      .click();
+  }
+}

--- a/e2e/pages/manageCases/createCase/C100/dummyCase/dummyC100ApplicantDetailsPage.ts
+++ b/e2e/pages/manageCases/createCase/C100/dummyCase/dummyC100ApplicantDetailsPage.ts
@@ -18,7 +18,7 @@ enum PageLoadFields {
   addressConfidentialNo = "#applicants_0_isAddressConfidential_No",
 }
 
-export class DummyApplicantDetailsPage {
+export class DummyC100ApplicantDetailsPage {
   public static async dummyApplicantDetailsPage(
     page: Page,
     applicantLivesInRefuge: boolean,

--- a/e2e/pages/manageCases/createCase/C100/dummyCase/dummyC100OtherPersonDetailsPage.ts
+++ b/e2e/pages/manageCases/createCase/C100/dummyCase/dummyC100OtherPersonDetailsPage.ts
@@ -21,7 +21,7 @@ enum PageLoadFields {
   otherPersonCurrentAddressNo = "#otherPartyInTheCaseRevised_0_isCurrentAddressKnown_No",
 }
 
-export class DummyOtherPersonDetailsPage {
+export class DummyC100OtherPersonDetailsPage {
   public static async dummyOtherPersonDetailsPage(
     page: Page,
     otherPersonLivesInRefuge: boolean,

--- a/e2e/pages/manageCases/createCase/FL401/applicantDetails/applicantDetailsSubmitPage.ts
+++ b/e2e/pages/manageCases/createCase/FL401/applicantDetails/applicantDetailsSubmitPage.ts
@@ -120,12 +120,12 @@ export class ApplicantDetailsSubmitPage {
         `${Selectors.a}:text-is("${ApplicantDetailsSubmitContent.applicantEmailAddress}")`,
         1,
       );
-      Helpers.checkVisibleAndPresent(
+      await Helpers.checkVisibleAndPresent(
         page,
         `${Selectors.GovukText16}:text-is("${ApplicantDetailsSubmitContent.uploadC8Form}")`,
         1,
       );
-      Helpers.checkVisibleAndPresent(
+      await Helpers.checkVisibleAndPresent(
         page,
         `${Selectors.a}:text-is("${ApplicantDetailsSubmitContent.uploadedFile}")`,
         1,

--- a/e2e/pages/manageCases/createCase/FL401/dummyCase/dummyFL401ApplicantDetailsPage.ts
+++ b/e2e/pages/manageCases/createCase/FL401/dummyCase/dummyFL401ApplicantDetailsPage.ts
@@ -1,0 +1,54 @@
+import { Page } from "@playwright/test";
+import { Selectors } from "../../../../../common/selectors";
+import { Helpers } from "../../../../../common/helpers";
+import config from "../../../../../config";
+import { ApplicantDetails1Content } from "../../../../../fixtures/manageCases/createCase/FL401/applicantDetails/applicantDetails1Content";
+
+enum UniqueSelectors {
+  uploadC8FormLabel = "label[for='applicantsFL401_refugeConfidentialityC8Form'] .form-label",
+  uploadC8FormHint = "label[for='applicantsFL401_refugeConfidentialityC8Form'] + .form-hint",
+  c8RefugeFormUploadFileInput = "#applicantsFL401_refugeConfidentialityC8Form",
+}
+
+enum PageLoadFields {
+  applicantLivesInRefugeYes = "#applicantsFL401_liveInRefuge_Yes",
+  applicantLivesInRefugeNo = "#applicantsFL401_liveInRefuge_No",
+  applicantPostCode = "#applicantsFL401_address_address_postcodeInput",
+  addressConfidentialYes = "#applicantsFL401_isAddressConfidential_Yes",
+  addressConfidentialNo = "#applicantsFL401_isAddressConfidential_No",
+}
+
+export class DummyFL401ApplicantDetailsPage {
+  public static async dummyApplicantDetailsPage(
+    page: Page,
+    applicantLivesInRefuge: boolean,
+  ): Promise<void> {
+    await page.waitForSelector(
+      `${Selectors.GovukHeadingL}:text-is("${ApplicantDetails1Content.headingL}")`,
+    );
+    if (applicantLivesInRefuge) {
+      await page.click(`${PageLoadFields.applicantLivesInRefugeYes}`);
+      await Helpers.checkVisibleAndPresent(
+        page,
+        `${UniqueSelectors.uploadC8FormLabel}:text-is("${ApplicantDetails1Content.formLabelC8FormUpload}")`,
+        1,
+      );
+      await Helpers.checkVisibleAndPresent(
+        page,
+        `${UniqueSelectors.uploadC8FormHint}:text-is("${ApplicantDetails1Content.c8FormUploadHint}")`,
+        1,
+      );
+      const fileInput = page.locator(
+        `${UniqueSelectors.c8RefugeFormUploadFileInput}`,
+      );
+      await fileInput.setInputFiles(config.testPdfFile);
+      await page.waitForSelector(
+        `${Selectors.GovukErrorMessage}:text-is("${ApplicantDetails1Content.uploadingFile}")`,
+        { state: "hidden" },
+      );
+      await page.click(`${PageLoadFields.addressConfidentialYes}`);
+    } else {
+      await page.click(`${PageLoadFields.applicantLivesInRefugeNo}`);
+    }
+  }
+}

--- a/e2e/tests/manageCases/caseTabs/fl401CaseTabs.spec.ts
+++ b/e2e/tests/manageCases/caseTabs/fl401CaseTabs.spec.ts
@@ -1,0 +1,67 @@
+import { test } from "@playwright/test";
+import Config from "../../../config";
+import { FL401CaseTabs } from "../../../journeys/manageCases/caseTabs/fl401CaseTabs";
+
+test.use({ storageState: Config.sessionStoragePath + "solicitor.json" });
+
+test.describe("FL401 Case tabs", (): void => {
+  test(`FL401 Case tabs with the following options:
+  Not Accessibility testing,
+  Not Error message testing,
+  Saying Yes to applicant lives in refuge,
+  Payment status paid. @regression`, async ({
+    page,
+    browser,
+  }): Promise<void> => {
+    await FL401CaseTabs.fl401CaseTabs({
+      page: page,
+      browser: browser,
+      errorMessaging: false,
+      accessibilityTest: false,
+      paymentStatusPaid: true,
+      caseType: "FL401",
+      applicantLivesInRefuge: true,
+      otherPersonLivesInRefuge: false,
+    });
+  });
+
+  test(`FL401 Case tabs with the following options:
+  Not Accessibility testing,
+  Not Error message testing,
+  Saying No to applicant lives in refuge,
+  Payment status paid. @regression`, async ({
+    page,
+    browser,
+  }): Promise<void> => {
+    await FL401CaseTabs.fl401CaseTabs({
+      page: page,
+      browser: browser,
+      errorMessaging: false,
+      accessibilityTest: false,
+      paymentStatusPaid: true,
+      caseType: "FL401",
+      applicantLivesInRefuge: false,
+      otherPersonLivesInRefuge: false,
+    });
+  });
+});
+
+test(`FL401 Case tabs with the following options:
+  Accessibility testing,
+  Not Error message testing,
+  Saying Yes to applicant lives in refuge,
+  Payment status paid. @accessibility @nightly`, async ({
+  page,
+  browser,
+}): Promise<void> => {
+  await FL401CaseTabs.fl401CaseTabs({
+    page: page,
+    browser: browser,
+    errorMessaging: false,
+    accessibilityTest: true,
+    paymentStatusPaid: true,
+    caseType: "FL401",
+    applicantLivesInRefuge: true,
+    otherPersonLivesInRefuge: false,
+  });
+});


### PR DESCRIPTION
### Description

This PR adds e2e tests for refuge details within Summary tab and Confidential details tabs. Tests are run locally against preview https://xui-prl-ccd-definitions-pr-2551.preview.platform.hmcts.net and are passing:

![image](https://github.com/user-attachments/assets/0257a50e-26b1-47e4-a409-428cc41aa882)

![image](https://github.com/user-attachments/assets/364eb0d6-561f-489b-a4b9-4dc64af82c05)

### JIRA link

https://tools.hmcts.net/jira/browse/PRL-6737
https://tools.hmcts.net/jira/browse/PRL-6738
