### PR TITLE
PRL-6682 & PRL-6795 Add tests for contact Preferences for Applicant and Respondent

### DIFF
--- a/e2e/common/types.ts
+++ b/e2e/common/types.ts
@@ -193,3 +193,5 @@ export type judgeTitles =
 export type yesNoNA = "Yes" | "No" | "Not applicable";
 
 export type courtAdminEvents = "Edit and serve an order";
+
+export type contactOption = "Digital" | "Post";

--- a/e2e/fixtures/citizen/caseView/applicant/contactPreferences/confirmationContent.ts
+++ b/e2e/fixtures/citizen/caseView/applicant/contactPreferences/confirmationContent.ts
@@ -1,0 +1,4 @@
+export enum ConfirmationContent {
+  GovukHeadingL = "Contact preferences updated",
+  GovukBodyM = "You will receive updates on the case by post.",
+}

--- a/e2e/fixtures/citizen/caseView/applicant/contactPreferences/contactPreferencesContent.ts
+++ b/e2e/fixtures/citizen/caseView/applicant/contactPreferences/contactPreferencesContent.ts
@@ -1,0 +1,15 @@
+export enum ContactPreferencesContent {
+  GovukHeadingXL = "Contact Preferences",
+  GovukBody1 = "You can choose to receive case updates by email or post.",
+  GovukBody2 = "If you receive updates by email, the updates will also be available to view in your dashboard.",
+  GovukBody3 = "This includes updates on:",
+  li1 = "court orders",
+  li2 = "hearings",
+  li3 = "decisions in your case",
+  GovukFieldsetLegend = "How would you prefer to be contacted?",
+  govukHint1 = "Select one of these options.",
+  govukHint2 = "All communication from the court will be sent by email.",
+  govukHint3 = "All communication from the court will be sent by post.",
+  digital = "Digital",
+  byPost = "Post",
+}

--- a/e2e/fixtures/citizen/caseView/applicant/contactPreferences/reviewContent.ts
+++ b/e2e/fixtures/citizen/caseView/applicant/contactPreferences/reviewContent.ts
@@ -1,0 +1,11 @@
+export enum ReviewContent {
+  GovukHeadingXL = "Contact Preferences",
+  GovukHeadingL = "Personal details",
+  GovukSummaryListKey = "Address",
+  GovukBody1 = "Heaven",
+  GovukBody2 = "7 Castle Square",
+  GovukBody3 = "Swansea",
+  GovukBody4 = "SA1 1DW",
+  GovukBody5 = "You have decided to receive updates by post.",
+  GovukBody6 = "You will no longer receive updates by email. You can still access previous updates through your dashboard.",
+}

--- a/e2e/fixtures/citizen/caseView/respondent/contactPreferences/confirmationContent.ts
+++ b/e2e/fixtures/citizen/caseView/respondent/contactPreferences/confirmationContent.ts
@@ -1,0 +1,4 @@
+export enum ConfirmationContent {
+  GovukHeadingL = "Contact preferences updated",
+  GovukBodyM = "You will receive updates on the case by post.",
+}

--- a/e2e/fixtures/citizen/caseView/respondent/contactPreferences/contactPreferencesContent.ts
+++ b/e2e/fixtures/citizen/caseView/respondent/contactPreferences/contactPreferencesContent.ts
@@ -1,0 +1,15 @@
+export enum ContactPreferencesContent {
+  GovukHeadingXL = "Contact Preferences",
+  GovukBody1 = "You can choose to receive case updates by email or post.",
+  GovukBody2 = "If you receive updates by email, the updates will also be available to view in your dashboard.",
+  GovukBody3 = "This includes updates on:",
+  li1 = "court orders",
+  li2 = "hearings",
+  li3 = "decisions in your case",
+  GovukFieldsetLegend = "How would you prefer to be contacted?",
+  govukHint1 = "Select one of these options.",
+  govukHint2 = "All communication from the court will be sent by email.",
+  govukHint3 = "All communication from the court will be sent by post.",
+  digital = "Digital",
+  byPost = "Post",
+}

--- a/e2e/fixtures/citizen/caseView/respondent/contactPreferences/reviewContent.ts
+++ b/e2e/fixtures/citizen/caseView/respondent/contactPreferences/reviewContent.ts
@@ -1,0 +1,11 @@
+export enum ReviewContent {
+  GovukHeadingXL = "Contact Preferences",
+  GovukHeadingL = "Personal details",
+  GovukSummaryListKey = "Address",
+  GovukBody1 = "Heaven",
+  GovukBody2 = "7 Castle Square",
+  GovukBody3 = "Swansea",
+  GovukBody4 = "SA1 1DW",
+  GovukBody5 = "You have decided to receive updates by post.",
+  GovukBody6 = "You will no longer receive updates by email. You can still access previous updates through your dashboard.",
+}

--- a/e2e/journeys/citizen/caseView/applicant/daCitizenApplicantDashboardTasks/daCitizenApplicantDashboardTasks.ts
+++ b/e2e/journeys/citizen/caseView/applicant/daCitizenApplicantDashboardTasks/daCitizenApplicantDashboardTasks.ts
@@ -5,6 +5,10 @@ import { DetailsKnownPage } from "../../../../../pages/citizen/caseView/applican
 import { StartAlternativePage } from "../../../../../pages/citizen/caseView/applicant/keepDetailsPrivate/startAlternativePage.ts";
 import { yesNoDontKnow } from "../../../../../common/types.ts";
 import { PrivateDetailsConfirmedPage } from "../../../../../pages/citizen/caseView/applicant/keepDetailsPrivate/privateDetailsConfirmedPage.ts";
+import { ConfirmationPage } from "../../../../../pages/citizen/caseView/applicant/contactPreferences/confirmationPage.ts";
+import { ReviewPage } from "../../../../../pages/citizen/caseView/applicant/contactPreferences/reviewPage.ts";
+import { ContactPreferencesPage } from "../../../../../pages/citizen/caseView/applicant/contactPreferences/contactPreferencesPage.ts";
+import { contactOption } from "../../../../../common/types.ts";
 
 interface daCitizenApplicantDashboardTasksParams {
   page: Page;
@@ -14,16 +18,18 @@ interface daCitizenApplicantDashboardTasksParams {
   event: Event; // the event parameter is meant to represent a different task the applicant can perform on the dashboard
   startAlternativeYesNo: boolean;
   yesNoDontKnow: yesNoDontKnow;
+  contactOption: contactOption;
 }
 
 // add your applicant task to this type to add your task to the switch statement
-export type Event = "confirmContactDetails" | "keepDetailsPrivate";
+export type Event = "confirmContactDetails" | "keepDetailsPrivate" | "contactPreferences";
 
 
 // This enum is used to store the locators for each event <a> tag on the applicant dashboard
 enum UniqueSelectors {
   confirmOrEditYourContactDetailsSelector = "#editYouContactDetails",
   keepDetailsPrivateSelector = "#keepYourDetailsPrivate",
+  contactPreferencesPrivateSelector = "#contactPreferences",
 }
 
 export class DaCitizenApplicantDashboardTasks {
@@ -35,6 +41,7 @@ export class DaCitizenApplicantDashboardTasks {
     event,
     startAlternativeYesNo,
     yesNoDontKnow,
+    contactOption,
   }: daCitizenApplicantDashboardTasksParams): Promise<void> {
     page = await ActivateCase.activateCase({
       page: page,
@@ -45,10 +52,11 @@ export class DaCitizenApplicantDashboardTasks {
     });
     switch (event) {
       case "confirmContactDetails":
-        await page.click(
-          UniqueSelectors.confirmOrEditYourContactDetailsSelector,
+        await page.click(UniqueSelectors.confirmOrEditYourContactDetailsSelector);
+        await CheckAnswersPage.checkAnswersPage(
+          page,
+          accessibilityTest
         );
-        await CheckAnswersPage.checkAnswersPage(page, accessibilityTest);
         break;
       case "keepDetailsPrivate":
         await page.click(UniqueSelectors.keepDetailsPrivateSelector);
@@ -67,6 +75,22 @@ export class DaCitizenApplicantDashboardTasks {
           accessibilityTest,
           startAlternativeYesNo,
         });
+        break;
+      case "contactPreferences":
+        await page.click(UniqueSelectors.contactPreferencesPrivateSelector);
+        await ContactPreferencesPage.contactPreferencesPage(
+          page,
+          accessibilityTest,
+          contactOption,
+        );
+        await ReviewPage.reviewPage(
+          page,
+          accessibilityTest,
+        );
+        await ConfirmationPage.confirmationPage(
+          page,
+          accessibilityTest,
+        );
         break;
     }
   }

--- a/e2e/journeys/citizen/caseView/respondent/daCitizenRespondentDashboardTasks/daCitizenRespondentDashboardTasks.ts
+++ b/e2e/journeys/citizen/caseView/respondent/daCitizenRespondentDashboardTasks/daCitizenRespondentDashboardTasks.ts
@@ -1,0 +1,97 @@
+import { Browser, Page } from "@playwright/test";
+import { ActivateCase } from "../../../activateCase/activateCase.ts";
+import { CheckAnswersPage } from "../../../../../pages/citizen/caseView/respondent/confirmContactDetails/checkAnswersPage.ts";
+// import { DetailsKnownPage } from "../../../../../pages/citizen/caseView/respondent/keepDetailsPrivate/detailsKnownPage.ts";
+// import { StartAlternativePage } from "../../../../../pages/citizen/caseView/respondent/keepDetailsPrivate/startAlternativePage.ts";
+// import { yesNoDontKnow } from "../../../../../common/types.ts";
+// import { PrivateDetailsConfirmedPage } from "../../../../../pages/citizen/caseView/respondent/keepDetailsPrivate/privateDetailsConfirmedPage.ts";
+import { ConfirmationPage } from "../../../../../pages/citizen/caseView/respondent/contactPreferences/confirmationPage.ts";
+import { ReviewPage } from "../../../../../pages/citizen/caseView/respondent/contactPreferences/reviewPage.ts";
+import { ContactPreferencesPage } from "../../../../../pages/citizen/caseView/respondent/contactPreferences/contactPreferencesPage.ts";
+import { contactOption } from "../../../../../common/types.ts";
+
+interface daCitizenRespondentDashboardTasksParams {
+  page: Page;
+  browser: Browser;
+  caseRef: string;
+  accessibilityTest: boolean;
+  event: Event; // the event parameter is meant to represent a different task the respondent can perform on the dashboard
+  startAlternativeYesNo: boolean;
+  // yesNoDontKnow: yesNoDontKnow;
+  contactOption: contactOption;
+}
+
+// add your respondent task to this type to add your task to the switch statement
+export type Event = "confirmContactDetails" | "keepDetailsPrivate" | "contactPreferences";
+
+
+// This enum is used to store the locators for each event <a> tag on the respondent dashboard
+enum UniqueSelectors {
+  confirmOrEditYourContactDetailsSelector = "#editYouContactDetails",
+  keepDetailsPrivateSelector = "#keepYourDetailsPrivate",
+  contactPreferencesPrivateSelector = "#contactPreferences",
+}
+
+export class DaCitizenRespondentDashboardTasks {
+  public static async daCitizenRespondentDashboardTasks({
+   page,
+   browser,
+   caseRef,
+   accessibilityTest,
+   event,
+   startAlternativeYesNo,
+   // yesNoDontKnow,
+   contactOption,
+ }: daCitizenRespondentDashboardTasksParams): Promise<void> {
+    page = await ActivateCase.activateCase({
+      page: page,
+      browser: browser,
+      caseRef: caseRef,
+      caseUser: "respondent",
+      accessibilityTest: accessibilityTest,
+    });
+    switch (event) {
+      case "confirmContactDetails":
+        await page.click(UniqueSelectors.confirmOrEditYourContactDetailsSelector);
+        await CheckAnswersPage.checkAnswersPage(
+          page,
+          accessibilityTest
+        );
+        break;
+      // case "keepDetailsPrivate":
+      //   await page.click(UniqueSelectors.keepDetailsPrivateSelector);
+      //   await DetailsKnownPage.details_knownPage(
+      //     page,
+      //     accessibilityTest,
+      //     yesNoDontKnow,
+      //   );
+      //   await StartAlternativePage.start_alternativePage({
+      //     page,
+      //     accessibilityTest,
+      //     startAlternativeYesNo,
+      //   });
+      //   await PrivateDetailsConfirmedPage.private_details_confirmedPage({
+      //     page,
+      //     accessibilityTest,
+      //     startAlternativeYesNo,
+      //   });
+      //   break;
+      case "contactPreferences":
+        await page.click(UniqueSelectors.contactPreferencesPrivateSelector);
+        await ContactPreferencesPage.contactPreferencesPage(
+          page,
+          accessibilityTest,
+          contactOption,
+        );
+        await ReviewPage.reviewPage(
+          page,
+          accessibilityTest,
+        );
+        await ConfirmationPage.confirmationPage(
+          page,
+          accessibilityTest,
+        );
+        break;
+    }
+  }
+}

--- a/e2e/pages/citizen/caseView/applicant/contactPreferences/confirmationPage.ts
+++ b/e2e/pages/citizen/caseView/applicant/contactPreferences/confirmationPage.ts
@@ -1,0 +1,44 @@
+import { Page } from "@playwright/test";
+import { Selectors } from "../../../../../common/selectors.ts";
+import { CommonStaticText } from "../../../../../common/commonStaticText.ts";
+import AccessibilityTestHelper from "../../../../../common/accessibilityTestHelper.ts";
+import { ConfirmationContent } from "../../../../../fixtures/citizen/caseView/applicant/contactPreferences/confirmationContent.ts";
+import { Helpers } from "../../../../../common/helpers.ts";
+
+export class ConfirmationPage {
+  public static async confirmationPage(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    // this part of the case is complete when the case is created through courtnav so only need to check the page
+    await this.checkPageLoads(page, accessibilityTest);
+    await this.saveAndContinue(page);
+  }
+
+  private static async checkPageLoads(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    await page
+      .locator(Selectors.GovukHeadingL, {
+        hasText: ConfirmationContent.GovukHeadingL,
+      })
+      .waitFor();
+    await Promise.all([
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukBodyM}:text-is("${ConfirmationContent.GovukBodyM}")`,
+        1,
+      ),
+    ]);
+    if (accessibilityTest) {
+      await AccessibilityTestHelper.run(page);
+    }
+  }
+
+  private static async saveAndContinue(page: Page): Promise<void> {
+    await page.click(
+      `${Selectors.GovukButton}:text-is("${CommonStaticText.continue}")`,
+    );
+  }
+}

--- a/e2e/pages/citizen/caseView/applicant/contactPreferences/contactPreferencesPage.ts
+++ b/e2e/pages/citizen/caseView/applicant/contactPreferences/contactPreferencesPage.ts
@@ -1,0 +1,100 @@
+import { Page } from "@playwright/test";
+import { Selectors } from "../../../../../common/selectors.ts";
+import { CommonStaticText } from "../../../../../common/commonStaticText.ts";
+import AccessibilityTestHelper from "../../../../../common/accessibilityTestHelper.ts";
+import { ContactPreferencesContent } from "../../../../../fixtures/citizen/caseView/applicant/contactPreferences/contactPreferencesContent.ts";
+import { Helpers } from "../../../../../common/helpers.ts";
+import { contactOption } from "../../../../../common/types.ts";
+
+enum UniqueSelectors {
+  digital = "#partyContactPreference",
+  byPost = "#partyContactPreference-2",
+}
+
+export class ContactPreferencesPage {
+  public static async contactPreferencesPage(
+    page: Page,
+    accessibilityTest: boolean,
+    contactOption: contactOption,
+  ): Promise<void> {
+    // this part of the case is complete when the case is created through courtnav so only need to check the page
+    await this.checkPageLoads(page, accessibilityTest);
+    await this.fillInFields(page, contactOption);
+  }
+
+  private static async checkPageLoads(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    await page
+      .locator(Selectors.GovukHeadingXL, {
+        hasText: ContactPreferencesContent.GovukHeadingXL,
+      })
+      .waitFor();
+    await Promise.all([
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukFieldsetLegend}:text-is("${ContactPreferencesContent.GovukFieldsetLegend}")`,
+        1,
+      ),
+      Helpers.checkGroup(
+        page,
+        3,
+        ContactPreferencesContent,
+        `GovukBody`,
+        `${Selectors.GovukBody}`,
+      ),
+      Helpers.checkGroup(
+        page,
+        3,
+        ContactPreferencesContent,
+        `li`,
+        `${Selectors.li}`,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHint}:text-is("${ContactPreferencesContent.govukHint1}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHint}:text-is("${ContactPreferencesContent.govukHint2}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHint}:text-is("${ContactPreferencesContent.govukHint3}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukLabel}:text-is("${ContactPreferencesContent.digital}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukLabel}:text-is("${ContactPreferencesContent.byPost}")`,
+        1,
+      ),
+    ]);
+    if (accessibilityTest) {
+      await AccessibilityTestHelper.run(page);
+    }
+  }
+
+  private static async fillInFields(
+    page: Page,
+    contactOption: contactOption,
+  ): Promise<void> {
+    if (contactOption === "Digital") {
+      await page.click(UniqueSelectors.digital);
+    } else if (contactOption === "Post") {
+      await page.click(UniqueSelectors.byPost)
+    } else {
+      throw new Error ("Invalid value for contactOption")
+    }
+    await page.click(
+      `${Selectors.GovukButton}:text-is("${CommonStaticText.saveAndContinue}")`,
+    );
+  }
+}

--- a/e2e/pages/citizen/caseView/applicant/contactPreferences/reviewPage.ts
+++ b/e2e/pages/citizen/caseView/applicant/contactPreferences/reviewPage.ts
@@ -1,0 +1,56 @@
+import { Page } from "@playwright/test";
+import { Selectors } from "../../../../../common/selectors.ts";
+import { CommonStaticText } from "../../../../../common/commonStaticText.ts";
+import AccessibilityTestHelper from "../../../../../common/accessibilityTestHelper.ts";
+import { ReviewContent } from "../../../../../fixtures/citizen/caseView/applicant/contactPreferences/reviewContent.ts";
+import { Helpers } from "../../../../../common/helpers.ts";
+
+export class ReviewPage {
+  public static async reviewPage(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    // this part of the case is complete when the case is created through courtnav so only need to check the page
+    await this.checkPageLoads(page, accessibilityTest);
+    await this.saveAndContinue(page);
+  }
+
+  private static async checkPageLoads(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    await page
+      .locator(Selectors.GovukHeadingXL, {
+        hasText: ReviewContent.GovukHeadingXL,
+      })
+      .waitFor();
+    await Promise.all([
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHeadingL}:text-is("${ReviewContent.GovukHeadingL}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukSummaryListKey}:text-is("${ReviewContent.GovukSummaryListKey}")`,
+        1,
+      ),
+      Helpers.checkGroup(
+        page,
+        6,
+        ReviewContent,
+        `GovukBody`,
+        `${Selectors.GovukBody}`,
+      ),
+    ]);
+    if (accessibilityTest) {
+      await AccessibilityTestHelper.run(page);
+    }
+  }
+
+  private static async saveAndContinue(page: Page): Promise<void> {
+    await page.click(
+      `${Selectors.GovukButton}:text-is("${CommonStaticText.continue}")`,
+    );
+  }
+}

--- a/e2e/pages/citizen/caseView/respondent/contactPreferences/confirmationPage.ts
+++ b/e2e/pages/citizen/caseView/respondent/contactPreferences/confirmationPage.ts
@@ -1,0 +1,44 @@
+import { Page } from "@playwright/test";
+import { Selectors } from "../../../../../common/selectors.ts";
+import { CommonStaticText } from "../../../../../common/commonStaticText.ts";
+import AccessibilityTestHelper from "../../../../../common/accessibilityTestHelper.ts";
+import { ConfirmationContent } from "../../../../../fixtures/citizen/caseView/respondent/contactPreferences/confirmationContent.ts";
+import { Helpers } from "../../../../../common/helpers.ts";
+
+export class ConfirmationPage {
+  public static async confirmationPage(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    // this part of the case is complete when the case is created through courtnav so only need to check the page
+    await this.checkPageLoads(page, accessibilityTest);
+    await this.saveAndContinue(page);
+  }
+
+  private static async checkPageLoads(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    await page
+      .locator(Selectors.GovukHeadingL, {
+        hasText: ConfirmationContent.GovukHeadingL,
+      })
+      .waitFor();
+    await Promise.all([
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukBodyM}:text-is("${ConfirmationContent.GovukBodyM}")`,
+        1,
+      ),
+    ]);
+    if (accessibilityTest) {
+      await AccessibilityTestHelper.run(page);
+    }
+  }
+
+  private static async saveAndContinue(page: Page): Promise<void> {
+    await page.click(
+      `${Selectors.GovukButton}:text-is("${CommonStaticText.continue}")`,
+    );
+  }
+}

--- a/e2e/pages/citizen/caseView/respondent/contactPreferences/contactPreferencesPage.ts
+++ b/e2e/pages/citizen/caseView/respondent/contactPreferences/contactPreferencesPage.ts
@@ -1,0 +1,100 @@
+import { Page } from "@playwright/test";
+import { Selectors } from "../../../../../common/selectors.ts";
+import { CommonStaticText } from "../../../../../common/commonStaticText.ts";
+import AccessibilityTestHelper from "../../../../../common/accessibilityTestHelper.ts";
+import { ContactPreferencesContent } from "../../../../../fixtures/citizen/caseView/respondent/contactPreferences/contactPreferencesContent.ts";
+import { Helpers } from "../../../../../common/helpers.ts";
+import { contactOption } from "../../../../../common/types.ts";
+
+enum UniqueSelectors {
+  digital = "#partyContactPreference",
+  byPost = "#partyContactPreference-2",
+}
+
+export class ContactPreferencesPage {
+  public static async contactPreferencesPage(
+    page: Page,
+    accessibilityTest: boolean,
+    contactOption: contactOption,
+  ): Promise<void> {
+    // this part of the case is complete when the case is created through courtnav so only need to check the page
+    await this.checkPageLoads(page, accessibilityTest);
+    await this.fillInFields(page, contactOption);
+  }
+
+  private static async checkPageLoads(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    await page
+      .locator(Selectors.GovukHeadingXL, {
+        hasText: ContactPreferencesContent.GovukHeadingXL,
+      })
+      .waitFor();
+    await Promise.all([
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukFieldsetLegend}:text-is("${ContactPreferencesContent.GovukFieldsetLegend}")`,
+        1,
+      ),
+      Helpers.checkGroup(
+        page,
+        3,
+        ContactPreferencesContent,
+        `GovukBody`,
+        `${Selectors.GovukBody}`,
+      ),
+      Helpers.checkGroup(
+        page,
+        3,
+        ContactPreferencesContent,
+        `li`,
+        `${Selectors.li}`,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHint}:text-is("${ContactPreferencesContent.govukHint1}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHint}:text-is("${ContactPreferencesContent.govukHint2}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHint}:text-is("${ContactPreferencesContent.govukHint3}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukLabel}:text-is("${ContactPreferencesContent.digital}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukLabel}:text-is("${ContactPreferencesContent.byPost}")`,
+        1,
+      ),
+    ]);
+    if (accessibilityTest) {
+      await AccessibilityTestHelper.run(page);
+    }
+  }
+
+  private static async fillInFields(
+    page: Page,
+    contactOption: contactOption,
+  ): Promise<void> {
+    if (contactOption === "Digital") {
+      await page.click(UniqueSelectors.digital);
+    } else if (contactOption === "Post") {
+      await page.click(UniqueSelectors.byPost)
+    } else {
+      throw new Error ("Invalid value for contactOption")
+    }
+    await page.click(
+      `${Selectors.GovukButton}:text-is("${CommonStaticText.saveAndContinue}")`,
+    );
+  }
+}

--- a/e2e/pages/citizen/caseView/respondent/contactPreferences/reviewPage.ts
+++ b/e2e/pages/citizen/caseView/respondent/contactPreferences/reviewPage.ts
@@ -1,0 +1,56 @@
+import { Page } from "@playwright/test";
+import { Selectors } from "../../../../../common/selectors.ts";
+import { CommonStaticText } from "../../../../../common/commonStaticText.ts";
+import AccessibilityTestHelper from "../../../../../common/accessibilityTestHelper.ts";
+import { ReviewContent } from "../../../../../fixtures/citizen/caseView/respondent/contactPreferences/reviewContent.ts";
+import { Helpers } from "../../../../../common/helpers.ts";
+
+export class ReviewPage {
+  public static async reviewPage(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    // this part of the case is complete when the case is created through courtnav so only need to check the page
+    await this.checkPageLoads(page, accessibilityTest);
+    await this.saveAndContinue(page);
+  }
+
+  private static async checkPageLoads(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    await page
+      .locator(Selectors.GovukHeadingXL, {
+        hasText: ReviewContent.GovukHeadingXL,
+      })
+      .waitFor();
+    await Promise.all([
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHeadingL}:text-is("${ReviewContent.GovukHeadingL}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukSummaryListKey}:text-is("${ReviewContent.GovukSummaryListKey}")`,
+        1,
+      ),
+      Helpers.checkGroup(
+        page,
+        6,
+        ReviewContent,
+        `GovukBody`,
+        `${Selectors.GovukBody}`,
+      ),
+    ]);
+    if (accessibilityTest) {
+      await AccessibilityTestHelper.run(page);
+    }
+  }
+
+  private static async saveAndContinue(page: Page): Promise<void> {
+    await page.click(
+      `${Selectors.GovukButton}:text-is("${CommonStaticText.continue}")`,
+    );
+  }
+}

--- a/e2e/tests/citizen/caseView/applicant/daCitizenApplicantEvents/contactPreferences/contactPreferences.spec.ts
+++ b/e2e/tests/citizen/caseView/applicant/daCitizenApplicantEvents/contactPreferences/contactPreferences.spec.ts
@@ -16,7 +16,7 @@ test.describe("Applicant confirm contact details tests", (): void => {
     await Helpers.goToCase(page, config.manageCasesBaseURL, ccdRef, "tasks");
   });
 
-  test("Applicant confirm contact details. @regression @accessibility @nightly", async ({
+  test("Applicant contact preferences. @regression @accessibility @nightly", async ({
     page,
     browser,
   }): Promise<void> => {
@@ -25,7 +25,7 @@ test.describe("Applicant confirm contact details tests", (): void => {
       browser: browser,
       caseRef: ccdRef,
       accessibilityTest: true,
-      event: "confirmContactDetails",
+      event: "contactPreferences",
       startAlternativeYesNo: true,
       yesNoDontKnow: "yes",
       contactOption: "Post"

--- a/e2e/tests/citizen/caseView/applicant/daCitizenApplicantEvents/keepDetailsPrivate/keepDetailsPrivate.spec.ts
+++ b/e2e/tests/citizen/caseView/applicant/daCitizenApplicantEvents/keepDetailsPrivate/keepDetailsPrivate.spec.ts
@@ -28,6 +28,7 @@ test.describe("Applicant confirm contact details tests", (): void => {
       event: "keepDetailsPrivate",
       startAlternativeYesNo: true,
       yesNoDontKnow: "yes",
+      contactOption: "Post"
     });
   });
 
@@ -43,6 +44,7 @@ test.describe("Applicant confirm contact details tests", (): void => {
       event: "keepDetailsPrivate",
       startAlternativeYesNo: false,
       yesNoDontKnow: "no",
+      contactOption: "Post"
     });
   });
 
@@ -58,6 +60,7 @@ test.describe("Applicant confirm contact details tests", (): void => {
       event: "keepDetailsPrivate",
       startAlternativeYesNo: true,
       yesNoDontKnow: "dontKnow",
+      contactOption: "Post"
     });
   });
 });

--- a/e2e/tests/citizen/caseView/respondent/daCitizenRespondentEvents/confirmContactDetails/confirmContactDetails.spec.ts
+++ b/e2e/tests/citizen/caseView/respondent/daCitizenRespondentEvents/confirmContactDetails/confirmContactDetails.spec.ts
@@ -1,9 +1,9 @@
 import { test } from "@playwright/test";
-import Config from "../../../../../config.ts";
-import config from "../../../../../config.ts";
-import createDaCitizenCourtNavCase from "../../../../../common/createCaseHelper.ts";
-import { Helpers } from "../../../../../common/helpers.ts";
-import { ConfirmContactDetails } from "../../../../../journeys/citizen/caseView/respondent/confirmContactDetails/confirmContactDetails.ts";
+import Config from "../../../../../../config.ts";
+import config from "../../../../../../config.ts";
+import createDaCitizenCourtNavCase from "../../../../../../common/createCaseHelper.ts";
+import { Helpers } from "../../../../../../common/helpers.ts";
+import { ConfirmContactDetails } from "../../../../../../journeys/citizen/caseView/respondent/confirmContactDetails/confirmContactDetails.ts";
 
 test.use({ storageState: Config.sessionStoragePath + "caseWorker.json" });
 

--- a/e2e/tests/citizen/caseView/respondent/daCitizenRespondentEvents/contactPreferences/contactPreferences.spec.ts
+++ b/e2e/tests/citizen/caseView/respondent/daCitizenRespondentEvents/contactPreferences/contactPreferences.spec.ts
@@ -3,11 +3,11 @@ import Config from "../../../../../../config.ts";
 import config from "../../../../../../config.ts";
 import createDaCitizenCourtNavCase from "../../../../../../common/createCaseHelper.ts";
 import { Helpers } from "../../../../../../common/helpers.ts";
-import { DaCitizenApplicantDashboardTasks } from "../../../../../../journeys/citizen/caseView/applicant/daCitizenApplicantDashboardTasks/daCitizenApplicantDashboardTasks.ts";
+import { DaCitizenRespondentDashboardTasks } from "../../../../../../journeys/citizen/caseView/respondent/daCitizenRespondentDashboardTasks/daCitizenRespondentDashboardTasks.ts";
 
 test.use({ storageState: Config.sessionStoragePath + "caseWorker.json" });
 
-test.describe("Applicant confirm contact details tests", (): void => {
+test.describe("Respondent confirm contact details tests", (): void => {
   test.slow();
   let ccdRef: string;
 
@@ -16,18 +16,18 @@ test.describe("Applicant confirm contact details tests", (): void => {
     await Helpers.goToCase(page, config.manageCasesBaseURL, ccdRef, "tasks");
   });
 
-  test("Applicant confirm contact details. @regression @accessibility @nightly", async ({
+  test("Respondent contact preferences. @regression @accessibility @nightly", async ({
     page,
     browser,
   }): Promise<void> => {
-    await DaCitizenApplicantDashboardTasks.daCitizenApplicantDashboardTasks({
+    await DaCitizenRespondentDashboardTasks.daCitizenRespondentDashboardTasks({
       page: page,
       browser: browser,
       caseRef: ccdRef,
       accessibilityTest: true,
-      event: "confirmContactDetails",
+      event: "contactPreferences",
       startAlternativeYesNo: true,
-      yesNoDontKnow: "yes",
+      // yesNoDontKnow: "yes",
       contactOption: "Post"
     });
   });


### PR DESCRIPTION
### Change description

Tests for citizen dashboard "Contact Preferences" (reasonable adjustments) pages for both applicant and respondent

### JIRA link

https://tools.hmcts.net/jira/browse/PRL-6682
https://tools.hmcts.net/jira/browse/PRL-6795

**Before merging a pull request make sure that:**

- [ ] Commits are meaningful and simple
- [ ] All commits are squashed into a single commit
- [ ] README and other documentation has been updated / added (if needed)
