### PR TITLE
PRL-6907-Request more time both applicant and respondent

### DIFF
--- a/e2e/common/commonStaticText.ts
+++ b/e2e/common/commonStaticText.ts
@@ -21,6 +21,7 @@ export enum CommonStaticText {
   provideMoreDetails = "Provide more details",
   saveAndContinue = "Save and continue",
   submitRequest = "Submit request",
+  submitApplication = "Submit Application",
   hearingRequest = "Request a hearing",
   startNow = "Start now",
   submitAndContinue = "Submit and continue",

--- a/e2e/fixtures/citizen/caseView/makeRequestToCourtAboutCase/applicant/listOfApplications1Content.ts
+++ b/e2e/fixtures/citizen/caseView/makeRequestToCourtAboutCase/applicant/listOfApplications1Content.ts
@@ -21,4 +21,5 @@ export enum ListOfApplications1Content {
   GovukBody7 = "You can ask for this when it may not be safe for you to deliver the court papers to the other person in a domestic abuse case.",
   GovukLink7 = "Apply to the court using form D89",
   next = "2 of 2",
+  formLink = "Apply to the court using form C2",
 }

--- a/e2e/fixtures/citizen/caseView/requestMoreTime/agreementForRequestContent.ts
+++ b/e2e/fixtures/citizen/caseView/requestMoreTime/agreementForRequestContent.ts
@@ -1,0 +1,8 @@
+export enum AgreementForRequestContent {
+  GovukCaptionL = "Request more time to do what is required by a court order",
+  GovukHeadingL = "Get agreement for your request",
+  GovukBodyM1 = "If you are able to, getting agreement from the other person in the case will reduce the fee you may have to pay.",
+  GovukBodyM2 = "You will need to provide proof of their agreement.",
+  GovukFieldsetLegend = "Does the other person in the case agree with this request?",
+  continue = "Continue",
+}

--- a/e2e/fixtures/citizen/caseView/requestMoreTime/agreementForRequestContent.ts
+++ b/e2e/fixtures/citizen/caseView/requestMoreTime/agreementForRequestContent.ts
@@ -4,5 +4,4 @@ export enum AgreementForRequestContent {
   GovukBodyM1 = "If you are able to, getting agreement from the other person in the case will reduce the fee you may have to pay.",
   GovukBodyM2 = "You will need to provide proof of their agreement.",
   GovukFieldsetLegend = "Does the other person in the case agree with this request?",
-  continue = "Continue",
 }

--- a/e2e/fixtures/citizen/caseView/requestMoreTime/checkAnswersContent.ts
+++ b/e2e/fixtures/citizen/caseView/requestMoreTime/checkAnswersContent.ts
@@ -10,5 +10,4 @@ export enum CheckAnswersContent {
   GovukSummaryListValueYes = "Yes",
   GovukSummaryListValue2 = "mockFile.pdf",
   GovukSummaryListValue3 = "Test123",
-  submitApplication = "Submit Application",
 }

--- a/e2e/fixtures/citizen/caseView/requestMoreTime/checkAnswersContent.ts
+++ b/e2e/fixtures/citizen/caseView/requestMoreTime/checkAnswersContent.ts
@@ -1,0 +1,14 @@
+export enum CheckAnswersContent {
+  GovukHeadingXL = "Check your answers",
+  GovukSummaryListKey1 = "What are you applying for?",
+  GovukSummaryListKey2 = "Does the other person in the case agree with the date change?",
+  GovukSummaryListKey3 = "Document uploaded",
+  GovukSummaryListKey4 = "Do you have supporting documents to upload?",
+  GovukSummaryListKey5 = "Will you be using help with fees to pay for this application?",
+  GovukSummaryListKey6 = "Help with fees reference number",
+  GovukSummaryListValue1 = "C2 application",
+  GovukSummaryListValueYes = "Yes",
+  GovukSummaryListValue2 = "mockFile.pdf",
+  GovukSummaryListValue3 = "Test123",
+  submitApplication = "Submit Application",
+}

--- a/e2e/fixtures/citizen/caseView/requestMoreTime/documentUploadContent.ts
+++ b/e2e/fixtures/citizen/caseView/requestMoreTime/documentUploadContent.ts
@@ -6,5 +6,4 @@ export enum DocumentUploadContent {
   GovukHint = "Give each document a file name that makes it clear what it is about. For example position-statement.docx. Files must end with JPG, JPEG, BMP, PNG, TIF, PDF, DOC or DOCX.",
   GovukSummaryText = "Take a picture of a document on your phone and upload it",
   GovukTableCell = "mockFile.pdf",
-  continue = "Continue",
 }

--- a/e2e/fixtures/citizen/caseView/requestMoreTime/documentUploadContent.ts
+++ b/e2e/fixtures/citizen/caseView/requestMoreTime/documentUploadContent.ts
@@ -1,0 +1,10 @@
+export enum DocumentUploadContent {
+  GovukCaptionL = "Request more time to do what is required by a court order",
+  GovukHeadingL = "Upload your application",
+  GovukBody = "If you are uploading a paper copy of the application, make sure this has been scanned in clearly and saved in a suitable format such as PDF.",
+  GovukHeadingS = "Upload your application form",
+  GovukHint = "Give each document a file name that makes it clear what it is about. For example position-statement.docx. Files must end with JPG, JPEG, BMP, PNG, TIF, PDF, DOC or DOCX.",
+  GovukSummaryText = "Take a picture of a document on your phone and upload it",
+  GovukTableCell = "mockFile.pdf",
+  continue = "Continue",
+}

--- a/e2e/fixtures/citizen/caseView/requestMoreTime/guidanceContent.ts
+++ b/e2e/fixtures/citizen/caseView/requestMoreTime/guidanceContent.ts
@@ -8,5 +8,4 @@ export enum GuidanceContent {
   GovukBody2 = "You can check the help with fees guidance on",
   GovukLink = "GOV.UK (opens in a new tab)",
   GovukBody3 = "to find out if you are eligible for support.",
-  startNow = "Start now",
 }

--- a/e2e/fixtures/citizen/caseView/requestMoreTime/guidanceContent.ts
+++ b/e2e/fixtures/citizen/caseView/requestMoreTime/guidanceContent.ts
@@ -1,0 +1,12 @@
+export enum GuidanceContent {
+  GovukCaptionL = "Make a C2 application",
+  GovukHeadingXL = "Request more time to do what is required by a court order",
+  GovukBody1 = "If you can get the other person in the case to agree to your request, the fee you may have to pay will reduce.",
+  GovukBodyApplicant = "Fees can be up to £0.00 depending on the information you provide.",
+  GovukBodyRespondent = "Fees can be up to £184.00 depending on the information you provide.",
+  GovukHeadingM = "Get help paying court fees",
+  GovukBody2 = "You can check the help with fees guidance on",
+  GovukLink = "GOV.UK (opens in a new tab)",
+  GovukBody3 = "to find out if you are eligible for support.",
+  startNow = "Start now",
+}

--- a/e2e/fixtures/citizen/caseView/requestMoreTime/helpWithFeesContent.ts
+++ b/e2e/fixtures/citizen/caseView/requestMoreTime/helpWithFeesContent.ts
@@ -1,0 +1,9 @@
+export enum HelpWithFeesContent {
+  GovukCaptionL = "Request more time to do what is required by a court order",
+  GovukHeadingL = "Help with fees",
+  GovukBodyM1 = "The cost of this application is £58.00. You can check the help with fees guidance on",
+  GovukLink = "GOV.UK (opens in a new tab)",
+  GovukBodyM2 = "to find out if you are eligible for support.",
+  GovukFieldsetLegend = "Will you be using help with fees to pay for this application?",
+  continue = "Continue",
+}

--- a/e2e/fixtures/citizen/caseView/requestMoreTime/helpWithFeesContent.ts
+++ b/e2e/fixtures/citizen/caseView/requestMoreTime/helpWithFeesContent.ts
@@ -5,5 +5,4 @@ export enum HelpWithFeesContent {
   GovukLink = "GOV.UK (opens in a new tab)",
   GovukBodyM2 = "to find out if you are eligible for support.",
   GovukFieldsetLegend = "Will you be using help with fees to pay for this application?",
-  continue = "Continue",
 }

--- a/e2e/fixtures/citizen/caseView/requestMoreTime/referenceContent.ts
+++ b/e2e/fixtures/citizen/caseView/requestMoreTime/referenceContent.ts
@@ -1,0 +1,9 @@
+export enum ReferenceContent {
+  GovukCaptionL = "Request more time to do what is required by a court order",
+  GovukHeadingL = "Do you have a help with fees reference number?",
+  GovukHeadingS = "Enter your help with fees reference number",
+  GovukLabel = "You will have received this number when you applied for Help with Fees. This reference must not have been used for a previous application.",
+  GovukHint = "For example, HWF-A1B-23C",
+  continue = "Continue",
+  refNumber = "Test123",
+}

--- a/e2e/fixtures/citizen/caseView/requestMoreTime/referenceContent.ts
+++ b/e2e/fixtures/citizen/caseView/requestMoreTime/referenceContent.ts
@@ -4,6 +4,5 @@ export enum ReferenceContent {
   GovukHeadingS = "Enter your help with fees reference number",
   GovukLabel = "You will have received this number when you applied for Help with Fees. This reference must not have been used for a previous application.",
   GovukHint = "For example, HWF-A1B-23C",
-  continue = "Continue",
   refNumber = "Test123",
 }

--- a/e2e/fixtures/citizen/caseView/requestMoreTime/supportingDocumentUploadContent.ts
+++ b/e2e/fixtures/citizen/caseView/requestMoreTime/supportingDocumentUploadContent.ts
@@ -1,0 +1,10 @@
+export enum SupportingDocumentUploadContent {
+  GovukCaptionL = "Request more time to do what is required by a court order",
+  GovukHeadingL = "Upload your supporting documents",
+  GovukBody = "If you are uploading a paper copy of the document, make sure this has been scanned in clearly and saved in a suitable format such as PDF.",
+  GovukHeadingS = "Upload documents",
+  GovukHint = "Give each document a file name that makes it clear what it is about. For example position-statement.docx. Files must end with JPG, JPEG, BMP, PNG, TIF, PDF, DOC or DOCX.",
+  GovukSummaryText = "Take a picture of a document on your phone and upload it",
+  GovukTableCell = "mockFile.pdf",
+  continue = "Continue",
+}

--- a/e2e/fixtures/citizen/caseView/requestMoreTime/supportingDocumentUploadContent.ts
+++ b/e2e/fixtures/citizen/caseView/requestMoreTime/supportingDocumentUploadContent.ts
@@ -6,5 +6,4 @@ export enum SupportingDocumentUploadContent {
   GovukHint = "Give each document a file name that makes it clear what it is about. For example position-statement.docx. Files must end with JPG, JPEG, BMP, PNG, TIF, PDF, DOC or DOCX.",
   GovukSummaryText = "Take a picture of a document on your phone and upload it",
   GovukTableCell = "mockFile.pdf",
-  continue = "Continue",
 }

--- a/e2e/fixtures/citizen/caseView/requestMoreTime/supportingDocumentsContent.ts
+++ b/e2e/fixtures/citizen/caseView/requestMoreTime/supportingDocumentsContent.ts
@@ -2,5 +2,4 @@ export enum SupportingDocumentsContent {
   GovukCaptionL = "Request more time to do what is required by a court order",
   GovukHeadingL = "Do you have supporting documents to upload?",
   GovukFieldsetLegend = "If you can show you have proof the other person in the case agrees to your request or you have any other supporting documents, you can upload them here.",
-  continue = "Continue",
 }

--- a/e2e/fixtures/citizen/caseView/requestMoreTime/supportingDocumentsContent.ts
+++ b/e2e/fixtures/citizen/caseView/requestMoreTime/supportingDocumentsContent.ts
@@ -1,0 +1,6 @@
+export enum SupportingDocumentsContent {
+  GovukCaptionL = "Request more time to do what is required by a court order",
+  GovukHeadingL = "Do you have supporting documents to upload?",
+  GovukFieldsetLegend = "If you can show you have proof the other person in the case agrees to your request or you have any other supporting documents, you can upload them here.",
+  continue = "Continue",
+}

--- a/e2e/fixtures/citizen/caseView/requestMoreTime/uploadYourApplicationContent.ts
+++ b/e2e/fixtures/citizen/caseView/requestMoreTime/uploadYourApplicationContent.ts
@@ -1,0 +1,7 @@
+export enum UploadYourApplicationContent {
+  GovukCaptionL = "Request more time to do what is required by a court order",
+  GovukHeadingL = "Upload your application",
+  GovukBodyM = "You will need to fill in the form C2 and upload it when submitting this request.",
+  GovukFieldsetLegend = "Have you already completed the C2 form?",
+  continue = "Continue",
+}

--- a/e2e/fixtures/citizen/caseView/requestMoreTime/uploadYourApplicationContent.ts
+++ b/e2e/fixtures/citizen/caseView/requestMoreTime/uploadYourApplicationContent.ts
@@ -3,5 +3,4 @@ export enum UploadYourApplicationContent {
   GovukHeadingL = "Upload your application",
   GovukBodyM = "You will need to fill in the form C2 and upload it when submitting this request.",
   GovukFieldsetLegend = "Have you already completed the C2 form?",
-  continue = "Continue",
 }

--- a/e2e/fixtures/citizen/caseView/requestMoreTime/urgentRequestContent.ts
+++ b/e2e/fixtures/citizen/caseView/requestMoreTime/urgentRequestContent.ts
@@ -1,0 +1,8 @@
+export enum UrgentRequestContent {
+  GovukCaptionL = "Request more time to do what is required by a court order",
+  GovukHeadingM = "Is there a reason why your request needs to be considered in the next five days?",
+  GovukLabel = "Give a reason why the court should consider your request urgently",
+  GovukHint = "For example, if there is an upcoming hearing or deadline set by the court.",
+  continue = "Continue",
+  reasonUrgentRequest = "Test",
+}

--- a/e2e/fixtures/citizen/caseView/requestMoreTime/urgentRequestContent.ts
+++ b/e2e/fixtures/citizen/caseView/requestMoreTime/urgentRequestContent.ts
@@ -3,6 +3,5 @@ export enum UrgentRequestContent {
   GovukHeadingM = "Is there a reason why your request needs to be considered in the next five days?",
   GovukLabel = "Give a reason why the court should consider your request urgently",
   GovukHint = "For example, if there is an upcoming hearing or deadline set by the court.",
-  continue = "Continue",
   reasonUrgentRequest = "Test",
 }

--- a/e2e/journeys/citizen/caseView/requestMoreTime/applicant/requestMoreTime.ts
+++ b/e2e/journeys/citizen/caseView/requestMoreTime/applicant/requestMoreTime.ts
@@ -9,6 +9,8 @@ import { SupportingDocumentUploadPage } from "../../../../../pages/citizen/caseV
 import { UrgentRequestPage } from "../../../../../pages/citizen/caseView/requestMoreTime/urgentRequestPage.ts";
 import { CheckAnswersApplicantPage } from "../../../../../pages/citizen/caseView/requestMoreTime/checkAnswersApplicantPage.ts";
 import { applicationSubmittedBy } from "../../../../../common/types.ts";
+import { Selectors } from "../../../../../common/selectors.ts";
+import { ListOfApplications1Content } from "../../../../../fixtures/citizen/caseView/makeRequestToCourtAboutCase/applicant/listOfApplications1Content.ts";
 
 interface requestMoreTimeParams {
   page: Page;
@@ -51,7 +53,7 @@ export class RequestMoreTime {
       isManualSOA: false,
     });
     await page.click(UniqueSelectors.requestToCourtAboutYourCase);
-    await page.click('a[href="/applicant/application-within-proceedings/C2/request-more-time/guidance"]');
+    await page.click(`${Selectors.a}:text-is("${ListOfApplications1Content.formLink}").nth(1)`);
     await GuidanceApplicantPage.guidanceApplicantPage(page, accessibilityTest);
     await UploadYourApplicationPage.uploadYourApplicationPage(page, accessibilityTest, completedForm);
     await AgreementForRequestPage.agreementForRequestPage(page, accessibilityTest, agreementForRequest);

--- a/e2e/journeys/citizen/caseView/requestMoreTime/applicant/requestMoreTime.ts
+++ b/e2e/journeys/citizen/caseView/requestMoreTime/applicant/requestMoreTime.ts
@@ -48,6 +48,7 @@ export class RequestMoreTime {
       caseUser: caseUser,
       accessibilityTest: accessibilityTest,
       applicationSubmittedBy: applicationSubmittedBy,
+      isManualSOA: false,
     });
     await page.click(UniqueSelectors.requestToCourtAboutYourCase);
     await page.click('a[href="/applicant/application-within-proceedings/C2/request-more-time/guidance"]');

--- a/e2e/journeys/citizen/caseView/requestMoreTime/applicant/requestMoreTime.ts
+++ b/e2e/journeys/citizen/caseView/requestMoreTime/applicant/requestMoreTime.ts
@@ -1,0 +1,63 @@
+import { ActivateCase, CaseUser } from "../../../activateCase/activateCase.ts";
+import { Browser, Page } from "@playwright/test";
+import { GuidanceApplicantPage } from "../../../../../pages/citizen/caseView/requestMoreTime/guidanceApplicantPage.ts";
+import { UploadYourApplicationPage } from "../../../../../pages/citizen/caseView/requestMoreTime/uploadYourApplicationPage.ts";
+import { AgreementForRequestPage } from "../../../../../pages/citizen/caseView/requestMoreTime/agreementForRequestPage.ts";
+import { DocumentUploadPage } from "../../../../../pages/citizen/caseView/requestMoreTime/documentUploadPage.ts";
+import { SupportingDocumentsPage } from "../../../../../pages/citizen/caseView/requestMoreTime/supportingDocumentsPage.ts";
+import { SupportingDocumentUploadPage } from "../../../../../pages/citizen/caseView/requestMoreTime/supportingDocumentUploadPage.ts";
+import { UrgentRequestPage } from "../../../../../pages/citizen/caseView/requestMoreTime/urgentRequestPage.ts";
+import { CheckAnswersApplicantPage } from "../../../../../pages/citizen/caseView/requestMoreTime/checkAnswersApplicantPage.ts";
+import { applicationSubmittedBy } from "../../../../../common/types.ts";
+
+interface requestMoreTimeParams {
+  page: Page;
+  browser: Browser;
+  caseRef: string;
+  accessibilityTest: boolean;
+  isApplicant: boolean;
+  applicationSubmittedBy: applicationSubmittedBy;
+  completedForm: boolean;
+  agreementForRequest: boolean;
+  supportingDocuments: boolean;
+  reasonUrgentRequest: boolean;
+}
+
+enum UniqueSelectors {
+  requestToCourtAboutYourCase = "#requestToCourtAboutYourCase",
+}
+
+export class RequestMoreTime {
+  public static async requestMoreTime({
+    page,
+    browser,
+    caseRef,
+    accessibilityTest,
+    isApplicant,
+    applicationSubmittedBy,
+    completedForm,
+    agreementForRequest,
+    supportingDocuments,
+    reasonUrgentRequest,
+  }: requestMoreTimeParams): Promise<void> {
+    const caseUser: CaseUser = isApplicant ? "applicant" : "respondent";
+    page = await ActivateCase.activateCase({
+      page: page,
+      browser: browser,
+      caseRef: caseRef,
+      caseUser: caseUser,
+      accessibilityTest: accessibilityTest,
+      applicationSubmittedBy: applicationSubmittedBy,
+    });
+    await page.click(UniqueSelectors.requestToCourtAboutYourCase);
+    await page.click('a[href="/applicant/application-within-proceedings/C2/request-more-time/guidance"]');
+    await GuidanceApplicantPage.guidanceApplicantPage(page, accessibilityTest);
+    await UploadYourApplicationPage.uploadYourApplicationPage(page, accessibilityTest, completedForm);
+    await AgreementForRequestPage.agreementForRequestPage(page, accessibilityTest, agreementForRequest);
+    await DocumentUploadPage.documentUploadPage(page, accessibilityTest);
+    await SupportingDocumentsPage.supportingDocumentsPage(page, accessibilityTest, supportingDocuments);
+    await SupportingDocumentUploadPage.supportingDocumentUploadPage(page, accessibilityTest);
+    await UrgentRequestPage.urgentRequestPage(page, accessibilityTest, reasonUrgentRequest);
+    await CheckAnswersApplicantPage.checkAnswersApplicantPage(page, accessibilityTest);
+  }
+}

--- a/e2e/journeys/citizen/caseView/requestMoreTime/applicant/requestMoreTime.ts
+++ b/e2e/journeys/citizen/caseView/requestMoreTime/applicant/requestMoreTime.ts
@@ -53,7 +53,7 @@ export class RequestMoreTime {
       isManualSOA: false,
     });
     await page.click(UniqueSelectors.requestToCourtAboutYourCase);
-    await page.click(`${Selectors.a}:text-is("${ListOfApplications1Content.formLink}").nth(1)`);
+    await page.locator(`${Selectors.GovukLink}:has-text("${ListOfApplications1Content.formLink}")`).nth(1).click();
     await GuidanceApplicantPage.guidanceApplicantPage(page, accessibilityTest);
     await UploadYourApplicationPage.uploadYourApplicationPage(page, accessibilityTest, completedForm);
     await AgreementForRequestPage.agreementForRequestPage(page, accessibilityTest, agreementForRequest);

--- a/e2e/journeys/citizen/caseView/requestMoreTime/respondent/requestMoreTime.ts
+++ b/e2e/journeys/citizen/caseView/requestMoreTime/respondent/requestMoreTime.ts
@@ -1,0 +1,71 @@
+import { ActivateCase, CaseUser } from "../../../activateCase/activateCase.ts";
+import { Browser, Page } from "@playwright/test";
+import { GuidanceRespondentPage } from "../../../../../pages/citizen/caseView/requestMoreTime/guidanceRespondentPage.ts";
+import { UploadYourApplicationPage } from "../../../../../pages/citizen/caseView/requestMoreTime/uploadYourApplicationPage.ts";
+import { AgreementForRequestPage } from "../../../../../pages/citizen/caseView/requestMoreTime/agreementForRequestPage.ts";
+import { HelpWithFeesPage } from "../../../../../pages/citizen/caseView/requestMoreTime/helpWithFeesPage.ts";
+import { ReferencePage } from "../../../../../pages/citizen/caseView/requestMoreTime/referencePage.ts";
+import { DocumentUploadPage } from "../../../../../pages/citizen/caseView/requestMoreTime/documentUploadPage.ts";
+import { SupportingDocumentsPage } from "../../../../../pages/citizen/caseView/requestMoreTime/supportingDocumentsPage.ts";
+import { SupportingDocumentUploadPage } from "../../../../../pages/citizen/caseView/requestMoreTime/supportingDocumentUploadPage.ts";
+import { UrgentRequestPage } from "../../../../../pages/citizen/caseView/requestMoreTime/urgentRequestPage.ts";
+import { CheckAnswersRespondentPage } from "../../../../../pages/citizen/caseView/requestMoreTime/checkAnswersRespondentPage.ts";
+import { applicationSubmittedBy } from "../../../../../common/types.ts";
+
+interface requestMoreTimeParams {
+  page: Page;
+  browser: Browser;
+  caseRef: string;
+  accessibilityTest: boolean;
+  isApplicant: boolean;
+  applicationSubmittedBy: applicationSubmittedBy;
+  completedForm: boolean;
+  agreementForRequest: boolean;
+  helpWithFees: boolean;
+  haveRefNumber: boolean;
+  supportingDocuments: boolean;
+  reasonUrgentRequest: boolean;
+}
+
+enum UniqueSelectors {
+  requestToCourtAboutYourCase = "#requestToCourtAboutYourCase",
+}
+
+export class RequestMoreTime {
+  public static async requestMoreTime({
+    page,
+    browser,
+    caseRef,
+    accessibilityTest,
+    isApplicant,
+    applicationSubmittedBy,
+    completedForm,
+    agreementForRequest,
+    helpWithFees,
+    haveRefNumber,
+    supportingDocuments,
+    reasonUrgentRequest,
+  }: requestMoreTimeParams): Promise<void> {
+    const caseUser: CaseUser = isApplicant ? "applicant" : "respondent";
+    page = await ActivateCase.activateCase({
+      page: page,
+      browser: browser,
+      caseRef: caseRef,
+      caseUser: caseUser,
+      accessibilityTest: accessibilityTest,
+      applicationSubmittedBy: applicationSubmittedBy,
+    });
+    await page.click(UniqueSelectors.requestToCourtAboutYourCase);
+    await page.click('a[href="/respondent/application-within-proceedings/C2/request-more-time/guidance"]');
+    await GuidanceRespondentPage.guidanceRespondentPage(page, accessibilityTest);
+    await UploadYourApplicationPage.uploadYourApplicationPage(page, accessibilityTest, completedForm);
+    await AgreementForRequestPage.agreementForRequestPage(page, accessibilityTest, agreementForRequest);
+    await HelpWithFeesPage.helpWithFeesPage(page, accessibilityTest, helpWithFees);
+    await ReferencePage.referencePage(page, accessibilityTest, haveRefNumber);
+    await DocumentUploadPage.documentUploadPage(page, accessibilityTest);
+    await SupportingDocumentsPage.supportingDocumentsPage(page, accessibilityTest, supportingDocuments);
+    await SupportingDocumentUploadPage.supportingDocumentUploadPage(page, accessibilityTest);
+    await UrgentRequestPage.urgentRequestPage(page, accessibilityTest, reasonUrgentRequest);
+    await CheckAnswersRespondentPage.checkAnswersRespondentPage(page, accessibilityTest);
+  }
+}

--- a/e2e/journeys/citizen/caseView/requestMoreTime/respondent/requestMoreTime.ts
+++ b/e2e/journeys/citizen/caseView/requestMoreTime/respondent/requestMoreTime.ts
@@ -59,7 +59,7 @@ export class RequestMoreTime {
       isManualSOA: false,
     });
     await page.click(UniqueSelectors.requestToCourtAboutYourCase);
-    await page.click(`${Selectors.a}:text-is("${ListOfApplications1Content.formLink}").nth(1)`);
+    await page.locator(`${Selectors.GovukLink}:has-text("${ListOfApplications1Content.formLink}")`).nth(1).click();
     await GuidanceRespondentPage.guidanceRespondentPage(page, accessibilityTest);
     await UploadYourApplicationPage.uploadYourApplicationPage(page, accessibilityTest, completedForm);
     await AgreementForRequestPage.agreementForRequestPage(page, accessibilityTest, agreementForRequest);

--- a/e2e/journeys/citizen/caseView/requestMoreTime/respondent/requestMoreTime.ts
+++ b/e2e/journeys/citizen/caseView/requestMoreTime/respondent/requestMoreTime.ts
@@ -54,6 +54,7 @@ export class RequestMoreTime {
       caseUser: caseUser,
       accessibilityTest: accessibilityTest,
       applicationSubmittedBy: applicationSubmittedBy,
+      isManualSOA: false,
     });
     await page.click(UniqueSelectors.requestToCourtAboutYourCase);
     await page.click('a[href="/respondent/application-within-proceedings/C2/request-more-time/guidance"]');

--- a/e2e/journeys/citizen/caseView/requestMoreTime/respondent/requestMoreTime.ts
+++ b/e2e/journeys/citizen/caseView/requestMoreTime/respondent/requestMoreTime.ts
@@ -11,6 +11,8 @@ import { SupportingDocumentUploadPage } from "../../../../../pages/citizen/caseV
 import { UrgentRequestPage } from "../../../../../pages/citizen/caseView/requestMoreTime/urgentRequestPage.ts";
 import { CheckAnswersRespondentPage } from "../../../../../pages/citizen/caseView/requestMoreTime/checkAnswersRespondentPage.ts";
 import { applicationSubmittedBy } from "../../../../../common/types.ts";
+import { Selectors } from "../../../../../common/selectors.ts";
+import { ListOfApplications1Content } from "../../../../../fixtures/citizen/caseView/makeRequestToCourtAboutCase/applicant/listOfApplications1Content.ts";
 
 interface requestMoreTimeParams {
   page: Page;
@@ -57,7 +59,7 @@ export class RequestMoreTime {
       isManualSOA: false,
     });
     await page.click(UniqueSelectors.requestToCourtAboutYourCase);
-    await page.click('a[href="/respondent/application-within-proceedings/C2/request-more-time/guidance"]');
+    await page.click(`${Selectors.a}:text-is("${ListOfApplications1Content.formLink}").nth(1)`);
     await GuidanceRespondentPage.guidanceRespondentPage(page, accessibilityTest);
     await UploadYourApplicationPage.uploadYourApplicationPage(page, accessibilityTest, completedForm);
     await AgreementForRequestPage.agreementForRequestPage(page, accessibilityTest, agreementForRequest);

--- a/e2e/pages/citizen/caseView/requestMoreTime/agreementForRequestPage.ts
+++ b/e2e/pages/citizen/caseView/requestMoreTime/agreementForRequestPage.ts
@@ -3,6 +3,7 @@ import { Selectors } from "../../../../common/selectors.ts";
 import AccessibilityTestHelper from "../../../../common/accessibilityTestHelper.ts";
 import { AgreementForRequestContent } from "../../../../fixtures/citizen/caseView/requestMoreTime/agreementForRequestContent.ts";
 import { Helpers } from "../../../../common/helpers.ts";
+import { CommonStaticText } from "../../../../common/commonStaticText.ts";
 
 enum UniqueSelectors {
   agreementForRequestYes = "#awp_agreementForRequest",
@@ -63,6 +64,6 @@ export class AgreementForRequestPage {
     else {
       await page.check(`${UniqueSelectors.agreementForRequestNo}`);
     }
-    await page.click(`${Selectors.GovukButton}:has-text("${AgreementForRequestContent.continue}")`,);
+    await page.click(`${Selectors.GovukButton}:text-is("${CommonStaticText.continue}")`,);
   }
 }

--- a/e2e/pages/citizen/caseView/requestMoreTime/agreementForRequestPage.ts
+++ b/e2e/pages/citizen/caseView/requestMoreTime/agreementForRequestPage.ts
@@ -1,0 +1,68 @@
+import { Page } from "@playwright/test";
+import { Selectors } from "../../../../common/selectors.ts";
+import AccessibilityTestHelper from "../../../../common/accessibilityTestHelper.ts";
+import { AgreementForRequestContent } from "../../../../fixtures/citizen/caseView/requestMoreTime/agreementForRequestContent.ts";
+import { Helpers } from "../../../../common/helpers.ts";
+
+enum UniqueSelectors {
+  agreementForRequestYes = "#awp_agreementForRequest",
+  agreementForRequestNo = "#awp_agreementForRequest-2",
+}
+
+export class AgreementForRequestPage {
+  public static async agreementForRequestPage(
+    page: Page,
+    accessibilityTest: boolean,
+    agreementForRequest: boolean,
+  ): Promise<void> {
+    // this part of the case is complete when the case is created through courtnav so only need to check the page
+    await this.checkPageLoads(page, accessibilityTest);
+    await this.fillInFields(page, agreementForRequest);
+  }
+
+  private static async checkPageLoads(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    await page
+      .locator(Selectors.GovukCaptionL, {
+        hasText: AgreementForRequestContent.GovukCaptionL,
+      })
+      .waitFor();
+    await Promise.all([
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHeadingL}:text-is("${AgreementForRequestContent.GovukHeadingL}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukFieldsetLegend}:text-is("${AgreementForRequestContent.GovukFieldsetLegend}")`,
+        1,
+      ),
+      Helpers.checkGroup(
+        page,
+        2,
+        AgreementForRequestContent,
+        `GovukBodyM`,
+        `${Selectors.GovukBodyM}`,
+      ),
+    ]);
+    if (accessibilityTest) {
+      await AccessibilityTestHelper.run(page);
+    }
+  }
+
+  private static async fillInFields(
+    page: Page,
+    agreementForRequest: boolean,
+  ): Promise<void>{
+    if(agreementForRequest) {
+      await page.check(`${UniqueSelectors.agreementForRequestYes}`);
+    }
+    else {
+      await page.check(`${UniqueSelectors.agreementForRequestNo}`);
+    }
+    await page.click(`${Selectors.GovukButton}:has-text("${AgreementForRequestContent.continue}")`,);
+  }
+}

--- a/e2e/pages/citizen/caseView/requestMoreTime/checkAnswersApplicantPage.ts
+++ b/e2e/pages/citizen/caseView/requestMoreTime/checkAnswersApplicantPage.ts
@@ -3,6 +3,7 @@ import { Selectors } from "../../../../common/selectors.ts";
 import AccessibilityTestHelper from "../../../../common/accessibilityTestHelper.ts";
 import { CheckAnswersContent } from "../../../../fixtures/citizen/caseView/requestMoreTime/checkAnswersContent.ts";
 import { Helpers } from "../../../../common/helpers.ts";
+import { CommonStaticText } from "../../../../common/commonStaticText.ts";
 
 export class CheckAnswersApplicantPage {
   public static async checkAnswersApplicantPage(
@@ -49,6 +50,6 @@ export class CheckAnswersApplicantPage {
     }
   }
   private static async submitApplication(page: Page): Promise<void> {
-    await page.click(`${Selectors.GovukButton}:has-text("${CheckAnswersContent.submitApplication}")`,);
+    await page.click(`${Selectors.GovukButton}:text-is("${CommonStaticText.submitApplication}")`,);
   }
 }

--- a/e2e/pages/citizen/caseView/requestMoreTime/checkAnswersApplicantPage.ts
+++ b/e2e/pages/citizen/caseView/requestMoreTime/checkAnswersApplicantPage.ts
@@ -1,0 +1,54 @@
+import { Page } from "@playwright/test";
+import { Selectors } from "../../../../common/selectors.ts";
+import AccessibilityTestHelper from "../../../../common/accessibilityTestHelper.ts";
+import { CheckAnswersContent } from "../../../../fixtures/citizen/caseView/requestMoreTime/checkAnswersContent.ts";
+import { Helpers } from "../../../../common/helpers.ts";
+
+export class CheckAnswersApplicantPage {
+  public static async checkAnswersApplicantPage(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    // this part of the case is complete when the case is created through courtnav so only need to check the page
+    await this.checkPageLoads(page, accessibilityTest);
+    await this.submitApplication(page);
+  }
+
+  private static async checkPageLoads(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    await page
+      .locator(Selectors.GovukHeadingXL, {
+        hasText: CheckAnswersContent.GovukHeadingXL,
+      })
+      .waitFor();
+    await Promise.all([
+      Helpers.checkGroup(
+        page,
+        4,
+        CheckAnswersContent,
+        `GovukSummaryListKey`,
+        `${Selectors.GovukSummaryListKey}`,
+      ),
+      Helpers.checkGroup(
+        page,
+        2,
+        CheckAnswersContent,
+        `GovukSummaryListValue`,
+        `${Selectors.GovukSummaryListValue}`,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukSummaryListValue}:text-is("${CheckAnswersContent.GovukSummaryListValueYes}")`,
+        2,
+      ),
+    ]);
+    if (accessibilityTest) {
+      await AccessibilityTestHelper.run(page);
+    }
+  }
+  private static async submitApplication(page: Page): Promise<void> {
+    await page.click(`${Selectors.GovukButton}:has-text("${CheckAnswersContent.submitApplication}")`,);
+  }
+}

--- a/e2e/pages/citizen/caseView/requestMoreTime/checkAnswersRespondentPage.ts
+++ b/e2e/pages/citizen/caseView/requestMoreTime/checkAnswersRespondentPage.ts
@@ -3,6 +3,7 @@ import { Selectors } from "../../../../common/selectors.ts";
 import AccessibilityTestHelper from "../../../../common/accessibilityTestHelper.ts";
 import { CheckAnswersContent } from "../../../../fixtures/citizen/caseView/requestMoreTime/checkAnswersContent.ts";
 import { Helpers } from "../../../../common/helpers.ts";
+import { CommonStaticText } from "../../../../common/commonStaticText.ts";
 
 export class CheckAnswersRespondentPage {
   public static async checkAnswersRespondentPage(
@@ -49,6 +50,6 @@ export class CheckAnswersRespondentPage {
     }
   }
   private static async submitApplication(page: Page): Promise<void> {
-    await page.click(`${Selectors.GovukButton}:has-text("${CheckAnswersContent.submitApplication}")`,);
+    await page.click(`${Selectors.GovukButton}:text-is("${CommonStaticText.submitApplication}")`,);
   }
 }

--- a/e2e/pages/citizen/caseView/requestMoreTime/checkAnswersRespondentPage.ts
+++ b/e2e/pages/citizen/caseView/requestMoreTime/checkAnswersRespondentPage.ts
@@ -1,0 +1,54 @@
+import { Page } from "@playwright/test";
+import { Selectors } from "../../../../common/selectors.ts";
+import AccessibilityTestHelper from "../../../../common/accessibilityTestHelper.ts";
+import { CheckAnswersContent } from "../../../../fixtures/citizen/caseView/requestMoreTime/checkAnswersContent.ts";
+import { Helpers } from "../../../../common/helpers.ts";
+
+export class CheckAnswersRespondentPage {
+  public static async checkAnswersRespondentPage(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    // this part of the case is complete when the case is created through courtnav so only need to check the page
+    await this.checkPageLoads(page, accessibilityTest);
+    await this.submitApplication(page);
+  }
+
+  private static async checkPageLoads(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    await page
+      .locator(Selectors.GovukHeadingXL, {
+        hasText: CheckAnswersContent.GovukHeadingXL,
+      })
+      .waitFor();
+    await Promise.all([
+      Helpers.checkGroup(
+        page,
+        6,
+        CheckAnswersContent,
+        `GovukSummaryListKey`,
+        `${Selectors.GovukSummaryListKey}`,
+      ),
+      Helpers.checkGroup(
+        page,
+        3,
+        CheckAnswersContent,
+        `GovukSummaryListValue`,
+        `${Selectors.GovukSummaryListValue}`,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukSummaryListValue}:text-is("${CheckAnswersContent.GovukSummaryListValueYes}")`,
+        3,
+      ),
+    ]);
+    if (accessibilityTest) {
+      await AccessibilityTestHelper.run(page);
+    }
+  }
+  private static async submitApplication(page: Page): Promise<void> {
+    await page.click(`${Selectors.GovukButton}:has-text("${CheckAnswersContent.submitApplication}")`,);
+  }
+}

--- a/e2e/pages/citizen/caseView/requestMoreTime/documentUploadPage.ts
+++ b/e2e/pages/citizen/caseView/requestMoreTime/documentUploadPage.ts
@@ -1,0 +1,77 @@
+import { Page } from "@playwright/test";
+import { Selectors } from "../../../../common/selectors.ts";
+import { CommonStaticText } from "../../../../common/commonStaticText.ts";
+import AccessibilityTestHelper from "../../../../common/accessibilityTestHelper.ts";
+import { DocumentUploadContent } from "../../../../fixtures/citizen/caseView/requestMoreTime/documentUploadContent.ts";
+import { Helpers } from "../../../../common/helpers.ts";
+import config from "../../../../config.ts";
+
+export enum UniqueSelectors {
+  fileUpload = "#awp-doc-form-upload",
+}
+
+export class DocumentUploadPage {
+  public static async documentUploadPage(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    // this part of the case is complete when the case is created through courtnav so only need to check the page
+    await this.checkPageLoads(page, accessibilityTest);
+    await this.fillInFields(page);
+  }
+
+  private static async checkPageLoads(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    await page
+      .locator(Selectors.GovukCaptionL, {
+        hasText: DocumentUploadContent.GovukCaptionL,
+      })
+      .waitFor();
+    await Promise.all([
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHeadingL}:text-is("${DocumentUploadContent.GovukHeadingL}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukBody}:text-is("${DocumentUploadContent.GovukBody}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHeadingS}:text-is("${DocumentUploadContent.GovukHeadingS}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHint}:text-is("${DocumentUploadContent.GovukHint}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukSummaryText}:text-is("${DocumentUploadContent.GovukSummaryText}")`,
+        1,
+      ),
+    ]);
+    if (accessibilityTest) {
+      await AccessibilityTestHelper.run(page);
+    }
+  }
+
+  private static async fillInFields(page: Page): Promise<void> {
+    const fileInput = page.locator(UniqueSelectors.fileUpload);
+    await fileInput.setInputFiles(config.testPdfFile);
+    await page.click(
+      `${Selectors.GovukButton}:text-is("${CommonStaticText.uploadFile}")`,
+    );
+    await Helpers.checkVisibleAndPresent(
+      page,
+      `${Selectors.GovukTableCell}:text-is("${DocumentUploadContent.GovukTableCell}")`,
+      1,
+    );
+    await page.click(`${Selectors.GovukButton}:has-text("${DocumentUploadContent.continue}")`,);
+  }
+}

--- a/e2e/pages/citizen/caseView/requestMoreTime/documentUploadPage.ts
+++ b/e2e/pages/citizen/caseView/requestMoreTime/documentUploadPage.ts
@@ -72,6 +72,6 @@ export class DocumentUploadPage {
       `${Selectors.GovukTableCell}:text-is("${DocumentUploadContent.GovukTableCell}")`,
       1,
     );
-    await page.click(`${Selectors.GovukButton}:has-text("${DocumentUploadContent.continue}")`,);
+    await page.click(`${Selectors.GovukButton}:text-is("${CommonStaticText.continue}")`,);
   }
 }

--- a/e2e/pages/citizen/caseView/requestMoreTime/guidanceApplicantPage.ts
+++ b/e2e/pages/citizen/caseView/requestMoreTime/guidanceApplicantPage.ts
@@ -3,6 +3,7 @@ import { Selectors } from "../../../../common/selectors.ts";
 import AccessibilityTestHelper from "../../../../common/accessibilityTestHelper.ts";
 import { GuidanceContent } from "../../../../fixtures/citizen/caseView/requestMoreTime/guidanceContent.ts";
 import { Helpers } from "../../../../common/helpers.ts";
+import { CommonStaticText } from "../../../../common/commonStaticText.ts";
 
 export class GuidanceApplicantPage {
   public static async guidanceApplicantPage(
@@ -57,6 +58,6 @@ export class GuidanceApplicantPage {
     }
   }
   private static async startNow(page: Page): Promise<void> {
-    await page.click(`${Selectors.GovukButton}:has-text("${GuidanceContent.startNow}")`,);
+    await page.click(`${Selectors.GovukButton}:text-is("${CommonStaticText.startNow}")`,);
   }
 }

--- a/e2e/pages/citizen/caseView/requestMoreTime/guidanceApplicantPage.ts
+++ b/e2e/pages/citizen/caseView/requestMoreTime/guidanceApplicantPage.ts
@@ -1,0 +1,62 @@
+import { Page } from "@playwright/test";
+import { Selectors } from "../../../../common/selectors.ts";
+import AccessibilityTestHelper from "../../../../common/accessibilityTestHelper.ts";
+import { GuidanceContent } from "../../../../fixtures/citizen/caseView/requestMoreTime/guidanceContent.ts";
+import { Helpers } from "../../../../common/helpers.ts";
+
+export class GuidanceApplicantPage {
+  public static async guidanceApplicantPage(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    // this part of the case is complete when the case is created through courtnav so only need to check the page
+    await this.checkPageLoads(page, accessibilityTest);
+    await this.startNow(page);
+  }
+
+  private static async checkPageLoads(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    await page
+      .locator(Selectors.GovukCaptionL, {
+        hasText: GuidanceContent.GovukCaptionL,
+      })
+      .waitFor();
+    await Promise.all([
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHeadingXL}:text-is("${GuidanceContent.GovukHeadingXL}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHeadingM}:text-is("${GuidanceContent.GovukHeadingM}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukLink}:text-is("${GuidanceContent.GovukLink}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukBody}:text-is("${GuidanceContent.GovukBodyApplicant}")`,
+        1,
+      ),
+      Helpers.checkGroup(
+        page,
+        3,
+        GuidanceContent,
+        `GovukBody`,
+        `${Selectors.GovukBody}`,
+      ),
+    ]);
+    if (accessibilityTest) {
+      await AccessibilityTestHelper.run(page);
+    }
+  }
+  private static async startNow(page: Page): Promise<void> {
+    await page.click(`${Selectors.GovukButton}:has-text("${GuidanceContent.startNow}")`,);
+  }
+}

--- a/e2e/pages/citizen/caseView/requestMoreTime/guidanceRespondentPage.ts
+++ b/e2e/pages/citizen/caseView/requestMoreTime/guidanceRespondentPage.ts
@@ -1,0 +1,62 @@
+import { Page } from "@playwright/test";
+import { Selectors } from "../../../../common/selectors.ts";
+import AccessibilityTestHelper from "../../../../common/accessibilityTestHelper.ts";
+import { GuidanceContent } from "../../../../fixtures/citizen/caseView/requestMoreTime/guidanceContent.ts";
+import { Helpers } from "../../../../common/helpers.ts";
+
+export class GuidanceRespondentPage {
+  public static async guidanceRespondentPage(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    // this part of the case is complete when the case is created through courtnav so only need to check the page
+    await this.checkPageLoads(page, accessibilityTest);
+    await this.startNow(page);
+  }
+
+  private static async checkPageLoads(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    await page
+      .locator(Selectors.GovukCaptionL, {
+        hasText: GuidanceContent.GovukCaptionL,
+      })
+      .waitFor();
+    await Promise.all([
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHeadingXL}:text-is("${GuidanceContent.GovukHeadingXL}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHeadingM}:text-is("${GuidanceContent.GovukHeadingM}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukLink}:text-is("${GuidanceContent.GovukLink}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukBody}:text-is("${GuidanceContent.GovukBodyRespondent}")`,
+        1,
+      ),
+      Helpers.checkGroup(
+        page,
+        3,
+        GuidanceContent,
+        `GovukBody`,
+        `${Selectors.GovukBody}`,
+      ),
+    ]);
+    if (accessibilityTest) {
+      await AccessibilityTestHelper.run(page);
+    }
+  }
+  private static async startNow(page: Page): Promise<void> {
+    await page.click(`${Selectors.GovukButton}:has-text("${GuidanceContent.startNow}")`,);
+  }
+}

--- a/e2e/pages/citizen/caseView/requestMoreTime/guidanceRespondentPage.ts
+++ b/e2e/pages/citizen/caseView/requestMoreTime/guidanceRespondentPage.ts
@@ -3,6 +3,7 @@ import { Selectors } from "../../../../common/selectors.ts";
 import AccessibilityTestHelper from "../../../../common/accessibilityTestHelper.ts";
 import { GuidanceContent } from "../../../../fixtures/citizen/caseView/requestMoreTime/guidanceContent.ts";
 import { Helpers } from "../../../../common/helpers.ts";
+import { CommonStaticText } from "../../../../common/commonStaticText.ts";
 
 export class GuidanceRespondentPage {
   public static async guidanceRespondentPage(
@@ -57,6 +58,6 @@ export class GuidanceRespondentPage {
     }
   }
   private static async startNow(page: Page): Promise<void> {
-    await page.click(`${Selectors.GovukButton}:has-text("${GuidanceContent.startNow}")`,);
+    await page.click(`${Selectors.GovukButton}:text-is("${CommonStaticText.startNow}")`,);
   }
 }

--- a/e2e/pages/citizen/caseView/requestMoreTime/helpWithFeesPage.ts
+++ b/e2e/pages/citizen/caseView/requestMoreTime/helpWithFeesPage.ts
@@ -1,0 +1,73 @@
+import { Page } from "@playwright/test";
+import { Selectors } from "../../../../common/selectors.ts";
+import AccessibilityTestHelper from "../../../../common/accessibilityTestHelper.ts";
+import { HelpWithFeesContent } from "../../../../fixtures/citizen/caseView/requestMoreTime/helpWithFeesContent.ts";
+import { Helpers } from "../../../../common/helpers.ts";
+
+enum UniqueSelectors {
+  helpWithFeesYes = "#awp_need_hwf",
+  helpWithFeesNo = "#awp_need_hwf-2",
+}
+
+export class HelpWithFeesPage {
+  public static async helpWithFeesPage(
+    page: Page,
+    accessibilityTest: boolean,
+    helpWithFees: boolean,
+  ): Promise<void> {
+    // this part of the case is complete when the case is created through courtnav so only need to check the page
+    await this.checkPageLoads(page, accessibilityTest);
+    await this.fillInFields(page, helpWithFees);
+  }
+
+  private static async checkPageLoads(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    await page
+      .locator(Selectors.GovukCaptionL, {
+        hasText: HelpWithFeesContent.GovukCaptionL,
+      })
+      .waitFor();
+    await Promise.all([
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHeadingL}:text-is("${HelpWithFeesContent.GovukHeadingL}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukLink}:text-is("${HelpWithFeesContent.GovukLink}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukFieldsetLegend}:text-is("${HelpWithFeesContent.GovukFieldsetLegend}")`,
+        1,
+      ),
+      Helpers.checkGroup(
+        page,
+        2,
+        HelpWithFeesContent,
+        `GovukBodyM`,
+        `${Selectors.GovukBodyM}`,
+      ),
+    ]);
+    if (accessibilityTest) {
+      await AccessibilityTestHelper.run(page);
+    }
+  }
+
+  private static async fillInFields(
+    page: Page,
+    helpWithFees: boolean,
+  ): Promise<void>{
+    if(helpWithFees) {
+      await page.check(`${UniqueSelectors.helpWithFeesYes}`);
+    }
+    else {
+      await page.check(`${UniqueSelectors.helpWithFeesNo}`);
+    }
+    await page.click(`${Selectors.GovukButton}:has-text("${HelpWithFeesContent.continue}")`,);
+  }
+}

--- a/e2e/pages/citizen/caseView/requestMoreTime/helpWithFeesPage.ts
+++ b/e2e/pages/citizen/caseView/requestMoreTime/helpWithFeesPage.ts
@@ -3,6 +3,7 @@ import { Selectors } from "../../../../common/selectors.ts";
 import AccessibilityTestHelper from "../../../../common/accessibilityTestHelper.ts";
 import { HelpWithFeesContent } from "../../../../fixtures/citizen/caseView/requestMoreTime/helpWithFeesContent.ts";
 import { Helpers } from "../../../../common/helpers.ts";
+import { CommonStaticText } from "../../../../common/commonStaticText.ts";
 
 enum UniqueSelectors {
   helpWithFeesYes = "#awp_need_hwf",
@@ -68,6 +69,6 @@ export class HelpWithFeesPage {
     else {
       await page.check(`${UniqueSelectors.helpWithFeesNo}`);
     }
-    await page.click(`${Selectors.GovukButton}:has-text("${HelpWithFeesContent.continue}")`,);
+    await page.click(`${Selectors.GovukButton}:text-is("${CommonStaticText.continue}")`,);
   }
 }

--- a/e2e/pages/citizen/caseView/requestMoreTime/referencePage.ts
+++ b/e2e/pages/citizen/caseView/requestMoreTime/referencePage.ts
@@ -3,6 +3,7 @@ import { Selectors } from "../../../../common/selectors.ts";
 import AccessibilityTestHelper from "../../../../common/accessibilityTestHelper.ts";
 import { ReferenceContent } from "../../../../fixtures/citizen/caseView/requestMoreTime/referenceContent.ts";
 import { Helpers } from "../../../../common/helpers.ts";
+import { CommonStaticText } from "../../../../common/commonStaticText.ts";
 
 enum UniqueSelectors {
   haveRefNumberYes = "#awp_have_hwfReference",
@@ -68,6 +69,6 @@ export class ReferencePage {
     else {
       await page.check(`${UniqueSelectors.haveRefNumberNo}`);
     }
-    await page.click(`${Selectors.GovukButton}:has-text("${ReferenceContent.continue}")`,);
+    await page.click(`${Selectors.GovukButton}:text-is("${CommonStaticText.continue}")`,);
   }
 }

--- a/e2e/pages/citizen/caseView/requestMoreTime/referencePage.ts
+++ b/e2e/pages/citizen/caseView/requestMoreTime/referencePage.ts
@@ -1,0 +1,73 @@
+import { Page } from "@playwright/test";
+import { Selectors } from "../../../../common/selectors.ts";
+import AccessibilityTestHelper from "../../../../common/accessibilityTestHelper.ts";
+import { ReferenceContent } from "../../../../fixtures/citizen/caseView/requestMoreTime/referenceContent.ts";
+import { Helpers } from "../../../../common/helpers.ts";
+
+enum UniqueSelectors {
+  haveRefNumberYes = "#awp_have_hwfReference",
+  haveRefNumberNo = "#awp_have_hwfReference-2",
+  addRefNumber = "#awp_hwf_referenceNumber",
+}
+
+export class ReferencePage {
+  public static async referencePage(
+    page: Page,
+    accessibilityTest: boolean,
+    haveRefNumber: boolean,
+  ): Promise<void> {
+    // this part of the case is complete when the case is created through courtnav so only need to check the page
+    await this.checkPageLoads(page, accessibilityTest);
+    await this.fillInFields(page, haveRefNumber);
+  }
+
+  private static async checkPageLoads(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    await page
+      .locator(Selectors.GovukCaptionL, {
+        hasText: ReferenceContent.GovukCaptionL,
+      })
+      .waitFor();
+    await Promise.all([
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHeadingL}:text-is("${ReferenceContent.GovukHeadingL}")`,
+        1,
+      ),
+    ]);
+    if (accessibilityTest) {
+      await AccessibilityTestHelper.run(page);
+    }
+  }
+  private static async fillInFields(
+    page: Page,
+    haveRefNumber: boolean,
+    ): Promise<void>{
+    if(haveRefNumber) {
+      await page.check(`${UniqueSelectors.haveRefNumberYes}`);
+      await Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHeadingS}:text-is("${ReferenceContent.GovukHeadingS}")`,
+        1,
+      );
+      await Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukLabel}:text-is("${ReferenceContent.GovukLabel}")`,
+        1,
+      );
+      await Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHint}:text-is("${ReferenceContent.GovukHint}")`,
+        1,
+      );
+      await page.fill(`${UniqueSelectors.addRefNumber}`, ReferenceContent.refNumber,
+      );
+    }
+    else {
+      await page.check(`${UniqueSelectors.haveRefNumberNo}`);
+    }
+    await page.click(`${Selectors.GovukButton}:has-text("${ReferenceContent.continue}")`,);
+  }
+}

--- a/e2e/pages/citizen/caseView/requestMoreTime/supportingDocumentUploadPage.ts
+++ b/e2e/pages/citizen/caseView/requestMoreTime/supportingDocumentUploadPage.ts
@@ -72,6 +72,6 @@ export class SupportingDocumentUploadPage {
       `${Selectors.GovukTableCell}:text-is("${SupportingDocumentUploadContent.GovukTableCell}")`,
       1,
     );
-    await page.click(`${Selectors.GovukButton}:has-text("${SupportingDocumentUploadContent.continue}")`,);
+    await page.click(`${Selectors.GovukButton}:text-is("${CommonStaticText.continue}")`,);
   }
 }

--- a/e2e/pages/citizen/caseView/requestMoreTime/supportingDocumentUploadPage.ts
+++ b/e2e/pages/citizen/caseView/requestMoreTime/supportingDocumentUploadPage.ts
@@ -1,0 +1,77 @@
+import { Page } from "@playwright/test";
+import { Selectors } from "../../../../common/selectors.ts";
+import { CommonStaticText } from "../../../../common/commonStaticText.ts";
+import AccessibilityTestHelper from "../../../../common/accessibilityTestHelper.ts";
+import { SupportingDocumentUploadContent } from "../../../../fixtures/citizen/caseView/requestMoreTime/supportingDocumentUploadContent.ts";
+import { Helpers } from "../../../../common/helpers.ts";
+import config from "../../../../config.ts";
+
+export enum UniqueSelectors {
+  fileUpload = "#awp-doc-form-upload",
+}
+
+export class SupportingDocumentUploadPage {
+  public static async supportingDocumentUploadPage(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    // this part of the case is complete when the case is created through courtnav so only need to check the page
+    await this.checkPageLoads(page, accessibilityTest);
+    await this.fillInFields(page);
+  }
+
+  private static async checkPageLoads(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    await page
+      .locator(Selectors.GovukCaptionL, {
+        hasText: SupportingDocumentUploadContent.GovukCaptionL,
+      })
+      .waitFor();
+    await Promise.all([
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHeadingL}:text-is("${SupportingDocumentUploadContent.GovukHeadingL}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukBody}:text-is("${SupportingDocumentUploadContent.GovukBody}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHeadingS}:text-is("${SupportingDocumentUploadContent.GovukHeadingS}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHint}:text-is("${SupportingDocumentUploadContent.GovukHint}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukSummaryText}:text-is("${SupportingDocumentUploadContent.GovukSummaryText}")`,
+        1,
+      ),
+    ]);
+    if (accessibilityTest) {
+      await AccessibilityTestHelper.run(page);
+    }
+  }
+
+  private static async fillInFields(page: Page): Promise<void> {
+    const fileInput = page.locator(UniqueSelectors.fileUpload);
+    await fileInput.setInputFiles(config.testPdfFile);
+    await page.click(
+      `${Selectors.GovukButton}:text-is("${CommonStaticText.uploadFile}")`,
+    );
+    await Helpers.checkVisibleAndPresent(
+      page,
+      `${Selectors.GovukTableCell}:text-is("${SupportingDocumentUploadContent.GovukTableCell}")`,
+      1,
+    );
+    await page.click(`${Selectors.GovukButton}:has-text("${SupportingDocumentUploadContent.continue}")`,);
+  }
+}

--- a/e2e/pages/citizen/caseView/requestMoreTime/supportingDocumentsPage.ts
+++ b/e2e/pages/citizen/caseView/requestMoreTime/supportingDocumentsPage.ts
@@ -1,0 +1,61 @@
+import { Page } from "@playwright/test";
+import { Selectors } from "../../../../common/selectors.ts";
+import AccessibilityTestHelper from "../../../../common/accessibilityTestHelper.ts";
+import { SupportingDocumentsContent } from "../../../../fixtures/citizen/caseView/requestMoreTime/supportingDocumentsContent.ts";
+import { Helpers } from "../../../../common/helpers.ts";
+
+enum UniqueSelectors {
+  supportingDocumentsYes = "#awp_hasSupportingDocuments",
+  supportingDocumentsNo = "#awp_hasSupportingDocuments-2",
+}
+
+export class SupportingDocumentsPage {
+  public static async supportingDocumentsPage(
+    page: Page,
+    accessibilityTest: boolean,
+    supportingDocuments: boolean,
+  ): Promise<void> {
+    // this part of the case is complete when the case is created through courtnav so only need to check the page
+    await this.checkPageLoads(page, accessibilityTest);
+    await this.fillInFields(page, supportingDocuments);
+  }
+
+  private static async checkPageLoads(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    await page
+      .locator(Selectors.GovukCaptionL, {
+        hasText: SupportingDocumentsContent.GovukCaptionL,
+      })
+      .waitFor();
+    await Promise.all([
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHeadingL}:text-is("${SupportingDocumentsContent.GovukHeadingL}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukFieldsetLegend}:text-is("${SupportingDocumentsContent.GovukFieldsetLegend}")`,
+        1,
+      ),
+    ]);
+    if (accessibilityTest) {
+      await AccessibilityTestHelper.run(page);
+    }
+  }
+
+  private static async fillInFields(
+    page: Page,
+    supportingDocuments: boolean,
+  ): Promise<void>{
+    if(supportingDocuments) {
+      await page.check(`${UniqueSelectors.supportingDocumentsYes}`);
+    }
+    else {
+      await page.check(`${UniqueSelectors.supportingDocumentsNo}`);
+    }
+    await page.click(`${Selectors.GovukButton}:has-text("${SupportingDocumentsContent.continue}")`,);
+  }
+}

--- a/e2e/pages/citizen/caseView/requestMoreTime/supportingDocumentsPage.ts
+++ b/e2e/pages/citizen/caseView/requestMoreTime/supportingDocumentsPage.ts
@@ -3,6 +3,7 @@ import { Selectors } from "../../../../common/selectors.ts";
 import AccessibilityTestHelper from "../../../../common/accessibilityTestHelper.ts";
 import { SupportingDocumentsContent } from "../../../../fixtures/citizen/caseView/requestMoreTime/supportingDocumentsContent.ts";
 import { Helpers } from "../../../../common/helpers.ts";
+import { CommonStaticText } from "../../../../common/commonStaticText.ts";
 
 enum UniqueSelectors {
   supportingDocumentsYes = "#awp_hasSupportingDocuments",
@@ -56,6 +57,6 @@ export class SupportingDocumentsPage {
     else {
       await page.check(`${UniqueSelectors.supportingDocumentsNo}`);
     }
-    await page.click(`${Selectors.GovukButton}:has-text("${SupportingDocumentsContent.continue}")`,);
+    await page.click(`${Selectors.GovukButton}:text-is("${CommonStaticText.continue}")`,);
   }
 }

--- a/e2e/pages/citizen/caseView/requestMoreTime/uploadYourApplicationPage.ts
+++ b/e2e/pages/citizen/caseView/requestMoreTime/uploadYourApplicationPage.ts
@@ -1,0 +1,65 @@
+import { Page } from "@playwright/test";
+import { Selectors } from "../../../../common/selectors.ts";
+import AccessibilityTestHelper from "../../../../common/accessibilityTestHelper.ts";
+import { UploadYourApplicationContent } from "../../../../fixtures/citizen/caseView/requestMoreTime/uploadYourApplicationContent.ts";
+import { Helpers } from "../../../../common/helpers.ts";
+
+enum UniqueSelectors {
+  completedFormYes = "#awp_completedForm",
+  completedFormNo = "#awp_completedForm-2",
+}
+
+export class UploadYourApplicationPage {
+  public static async uploadYourApplicationPage(
+    page: Page,
+    accessibilityTest: boolean,
+    completedForm: boolean,
+  ): Promise<void> {
+    // this part of the case is complete when the case is created through courtnav so only need to check the page
+    await this.checkPageLoads(page, accessibilityTest);
+    await this.fillInFields(page, completedForm);
+  }
+
+  private static async checkPageLoads(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    await page
+      .locator(Selectors.GovukCaptionL, {
+        hasText: UploadYourApplicationContent.GovukCaptionL,
+      })
+      .waitFor();
+    await Promise.all([
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHeadingL}:text-is("${UploadYourApplicationContent.GovukHeadingL}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukBodyM}:text-is("${UploadYourApplicationContent.GovukBodyM}")`,
+        1,
+      ),
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukFieldsetLegend}:text-is("${UploadYourApplicationContent.GovukFieldsetLegend}")`,
+        1,
+      ),
+    ]);
+    if (accessibilityTest) {
+      await AccessibilityTestHelper.run(page);
+    }
+  }
+
+  private static async fillInFields(
+    page: Page,
+    completedForm: boolean,
+  ): Promise<void> {
+    if (completedForm) {
+      await page.check(`${UniqueSelectors.completedFormYes}`);
+    } else {
+      await page.check(`${UniqueSelectors.completedFormNo}`);
+    }
+    await page.click(`${Selectors.GovukButton}:has-text("${UploadYourApplicationContent.continue}")`,);
+  }
+}

--- a/e2e/pages/citizen/caseView/requestMoreTime/uploadYourApplicationPage.ts
+++ b/e2e/pages/citizen/caseView/requestMoreTime/uploadYourApplicationPage.ts
@@ -3,6 +3,7 @@ import { Selectors } from "../../../../common/selectors.ts";
 import AccessibilityTestHelper from "../../../../common/accessibilityTestHelper.ts";
 import { UploadYourApplicationContent } from "../../../../fixtures/citizen/caseView/requestMoreTime/uploadYourApplicationContent.ts";
 import { Helpers } from "../../../../common/helpers.ts";
+import { CommonStaticText } from "../../../../common/commonStaticText.ts";
 
 enum UniqueSelectors {
   completedFormYes = "#awp_completedForm",
@@ -60,6 +61,6 @@ export class UploadYourApplicationPage {
     } else {
       await page.check(`${UniqueSelectors.completedFormNo}`);
     }
-    await page.click(`${Selectors.GovukButton}:has-text("${UploadYourApplicationContent.continue}")`,);
+    await page.click(`${Selectors.GovukButton}:text-is("${CommonStaticText.continue}")`,);
   }
 }

--- a/e2e/pages/citizen/caseView/requestMoreTime/urgentRequestPage.ts
+++ b/e2e/pages/citizen/caseView/requestMoreTime/urgentRequestPage.ts
@@ -1,0 +1,68 @@
+import { Page } from "@playwright/test";
+import { Selectors } from "../../../../common/selectors.ts";
+import AccessibilityTestHelper from "../../../../common/accessibilityTestHelper.ts";
+import { UrgentRequestContent } from "../../../../fixtures/citizen/caseView/requestMoreTime/urgentRequestContent.ts";
+import { Helpers } from "../../../../common/helpers.ts";
+
+enum UniqueSelectors {
+  reasonUrgentRequestYes = "#awp_isThereReasonForUrgentRequest",
+  reasonUrgentRequestNo = "#awp_isThereReasonForUrgentRequest-2",
+  addRefNumber = "#awp_urgentRequestReason",
+}
+
+export class UrgentRequestPage {
+  public static async urgentRequestPage(
+    page: Page,
+    accessibilityTest: boolean,
+    reasonUrgentRequest: boolean,
+  ): Promise<void> {
+    // this part of the case is complete when the case is created through courtnav so only need to check the page
+    await this.checkPageLoads(page, accessibilityTest);
+    await this.fillInFields(page, reasonUrgentRequest);
+  }
+
+  private static async checkPageLoads(
+    page: Page,
+    accessibilityTest: boolean,
+  ): Promise<void> {
+    await page
+      .locator(Selectors.GovukCaptionL, {
+        hasText: UrgentRequestContent.GovukCaptionL,
+      })
+      .waitFor();
+    await Promise.all([
+      Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHeadingM}:text-is("${UrgentRequestContent.GovukHeadingM}")`,
+        1,
+      ),
+    ]);
+    if (accessibilityTest) {
+      await AccessibilityTestHelper.run(page);
+    }
+  }
+  private static async fillInFields(
+    page: Page,
+    reasonUrgentRequest: boolean,
+  ): Promise<void>{
+    if(reasonUrgentRequest) {
+      await page.check(`${UniqueSelectors.reasonUrgentRequestYes}`);
+      await Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukLabel}:text-is("${UrgentRequestContent.GovukLabel}")`,
+        1,
+      );
+      await Helpers.checkVisibleAndPresent(
+        page,
+        `${Selectors.GovukHint}:text-is("${UrgentRequestContent.GovukHint}")`,
+        1,
+      );
+      await page.fill(`${UniqueSelectors.addRefNumber}`, UrgentRequestContent.reasonUrgentRequest,
+      );
+    }
+    else {
+      await page.check(`${UniqueSelectors.reasonUrgentRequestNo}`);
+    }
+    await page.click(`${Selectors.GovukButton}:has-text("${UrgentRequestContent.continue}")`,);
+  }
+}

--- a/e2e/pages/citizen/caseView/requestMoreTime/urgentRequestPage.ts
+++ b/e2e/pages/citizen/caseView/requestMoreTime/urgentRequestPage.ts
@@ -3,6 +3,7 @@ import { Selectors } from "../../../../common/selectors.ts";
 import AccessibilityTestHelper from "../../../../common/accessibilityTestHelper.ts";
 import { UrgentRequestContent } from "../../../../fixtures/citizen/caseView/requestMoreTime/urgentRequestContent.ts";
 import { Helpers } from "../../../../common/helpers.ts";
+import { CommonStaticText } from "../../../../common/commonStaticText.ts";
 
 enum UniqueSelectors {
   reasonUrgentRequestYes = "#awp_isThereReasonForUrgentRequest",
@@ -63,6 +64,6 @@ export class UrgentRequestPage {
     else {
       await page.check(`${UniqueSelectors.reasonUrgentRequestNo}`);
     }
-    await page.click(`${Selectors.GovukButton}:has-text("${UrgentRequestContent.continue}")`,);
+    await page.click(`${Selectors.GovukButton}:text-is("${CommonStaticText.continue}")`,);
   }
 }

--- a/e2e/tests/citizen/caseView/requestMoreTime/applicant/requestMoreTime.spec.ts
+++ b/e2e/tests/citizen/caseView/requestMoreTime/applicant/requestMoreTime.spec.ts
@@ -1,0 +1,36 @@
+import { test } from "@playwright/test";
+import Config from "../../../../../config.ts";
+import config from "../../../../../config.ts";
+import createDaCitizenCourtNavCase from "../../../../../common/createCaseHelper.ts";
+import { Helpers } from "../../../../../common/helpers.ts";
+import { RequestMoreTime } from "../../../../../journeys/citizen/caseView/requestMoreTime/applicant/requestMoreTime.ts";
+
+test.use({ storageState: Config.sessionStoragePath + "caseWorker.json" });
+
+test.describe("Applicant Request more time to do what is required by a court order tests", (): void => {
+  test.slow();
+  let ccdRef: string;
+
+  test.beforeEach(async ({ page }) => {
+    ccdRef = await createDaCitizenCourtNavCase(true, false);
+    await Helpers.goToCase(page, config.manageCasesBaseURL, ccdRef, "tasks");
+  });
+
+  test("Applicant Request more time without fees. @regression @nightly", async ({
+    page,
+    browser,
+  }): Promise<void> => {
+    await RequestMoreTime.requestMoreTime({
+      page: page,
+      browser: browser,
+      caseRef: ccdRef,
+      accessibilityTest: false,
+      isApplicant: true,
+      applicationSubmittedBy: "Citizen",
+      completedForm: true,
+      agreementForRequest: true,
+      supportingDocuments: true,
+      reasonUrgentRequest: true,
+    });
+  });
+});

--- a/e2e/tests/citizen/caseView/requestMoreTime/respondent/requestMoreTime.spec.ts
+++ b/e2e/tests/citizen/caseView/requestMoreTime/respondent/requestMoreTime.spec.ts
@@ -1,0 +1,38 @@
+import { test } from "@playwright/test";
+import Config from "../../../../../config.ts";
+import config from "../../../../../config.ts";
+import createDaCitizenCourtNavCase from "../../../../../common/createCaseHelper.ts";
+import { Helpers } from "../../../../../common/helpers.ts";
+import { RequestMoreTime } from "../../../../../journeys/citizen/caseView/requestMoreTime/respondent/requestMoreTime.ts";
+
+test.use({ storageState: Config.sessionStoragePath + "caseWorker.json" });
+
+test.describe("Respondent Request more time to do what is required by a court order tests", (): void => {
+  test.slow();
+  let ccdRef: string;
+
+  test.beforeEach(async ({ page }) => {
+    ccdRef = await createDaCitizenCourtNavCase(true, false);
+    await Helpers.goToCase(page, config.manageCasesBaseURL, ccdRef, "tasks");
+  });
+
+  test("Respondent Request more time with fees. @regression @nightly", async ({
+    page,
+    browser,
+  }): Promise<void> => {
+    await RequestMoreTime.requestMoreTime({
+      page: page,
+      browser: browser,
+      caseRef: ccdRef,
+      accessibilityTest: false,
+      isApplicant: false,
+      applicationSubmittedBy: "Citizen",
+      completedForm: true,
+      agreementForRequest: true,
+      helpWithFees: true,
+      haveRefNumber: true,
+      supportingDocuments: true,
+      reasonUrgentRequest: true,
+    });
+  });
+});


### PR DESCRIPTION
### Change description

This PR cover tests for Request more time to do what is required by a court order for applicant and respondent

Name of event: DA citizen dashboards

Number of pages: 12

Applicant and Respondent share most of the pages except following pages

guidance, checkAnswers

User(s) to complete event: Citizen

Dependency:

citizen has activated the case and has access to the dashboard.
Definition of done:

All happy and accessibility journeys are automated.
Jenkins PR build is passing and green.

### JIRA link

https://tools.hmcts.net/jira/browse/PRL-6907

**Before merging a pull request make sure that:**

- [ ] Commits are meaningful and simple
- [ ] All commits are squashed into a single commit
- [ ] README and other documentation has been updated / added (if needed)
