### PR TITLE
Turn trace on all retires in chromium

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -32,7 +32,7 @@ module.exports = defineConfig({
         channel: "chromium",
         screenshot: "off",
         video: "off",
-        trace: "on-first-retry",
+        trace: "on-all-retries",
         javaScriptEnabled: true,
         viewport: DEFAULT_VIEWPORT,
       },


### PR DESCRIPTION
help debug issues with tests, turning on trace for all retries
