### PR TITLE
remove dummy payment nightly tests

### DIFF
--- a/e2e/tests/manageCases/caseWorker/dummyPayment/c100DummyPaymentAwp.spec.ts
+++ b/e2e/tests/manageCases/caseWorker/dummyPayment/c100DummyPaymentAwp.spec.ts
@@ -55,7 +55,7 @@ test.describe("C100 Dummy payment for AWP tests", (): void => {
   test(`Complete the Dummy payment for AWP action  as a solicitor with the following options:
   Accessibility testing,
   Not Error message testing,
-  Payment status is paid. @accessibility @nightly`, async ({
+  Payment status is paid. @accessibility`, async ({
     page,
   }): Promise<void> => {
     await DummyPaymentAwp.dummyPaymentAwp({

--- a/e2e/tests/manageCases/caseWorker/dummyPayment/fl401DummyPaymentAwp.spec.ts
+++ b/e2e/tests/manageCases/caseWorker/dummyPayment/fl401DummyPaymentAwp.spec.ts
@@ -61,7 +61,7 @@ test.describe("FL401 Dummy payment for AWP tests", (): void => {
   test(`Complete the Dummy payment for AWP action  as a solicitor with the following options:
   Accessibility testing,
   Not Error message testing,
-  Payment status is paid. @accessibility @nightly`, async ({
+  Payment status is paid. @accessibility`, async ({
     page,
   }): Promise<void> => {
     await DummyPaymentAwp.dummyPaymentAwp({


### PR DESCRIPTION
tests not needed in nightly as they are testing functionality needed for testing and is not part of the user journey