### PR TITLE
Fix pipeline secret retrieval for preview environments

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -53,12 +53,12 @@ static Map < String, Object > secret(String secretName, String envVariable) {
   ]
 }
 
-def matchingEnv = "unknown"
+def matchingEnv = "aat"
 
 if(params.skipManageCasesTests) {
-  matchingEnv = params.CITIZEN_FRONTEND_BASE_URL.contains("demo") ? "demo" : "aat"
+  matchingEnv = params.CITIZEN_FRONTEND_BASE_URL.contains("demo") ? "demo" : matchingEnv
 } else {
-  matchingEnv = params.MANAGE_CASES_BASE_URL.contains("demo") ? "demo" : "aat"
+  matchingEnv = params.MANAGE_CASES_BASE_URL.contains("demo") ? "demo" : matchingEnv
 }
 
 def secrets = [

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -53,13 +53,12 @@ static Map < String, Object > secret(String secretName, String envVariable) {
   ]
 }
 
-def envSubstrings = ["aat", "demo", "preview"]
 def matchingEnv = "unknown"
 
 if(params.skipManageCasesTests) {
-  matchingEnv = envSubstrings.find{envSubstring -> params.CITIZEN_FRONTEND_BASE_URL.contains(envSubstring)}
+  matchingEnv = params.CITIZEN_FRONTEND_BASE_URL.contains("demo") ? "demo" : "aat"
 } else {
-  matchingEnv = envSubstrings.find{envSubstring -> params.MANAGE_CASES_BASE_URL.contains(envSubstring)}
+  matchingEnv = params.MANAGE_CASES_BASE_URL.contains("demo") ? "demo" : "aat"
 }
 
 def secrets = [

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -57,12 +57,12 @@ static Map < String, Object > secret(String secretName, String envVariable) {
   ]
 }
 
-def matchingEnv = "unknown"
+def matchingEnv = "aat"
 
 if(params.skipManageCasesTests) {
-  matchingEnv = params.CITIZEN_FRONTEND_BASE_URL.contains("demo") ? "demo" : "aat"
+  matchingEnv = params.CITIZEN_FRONTEND_BASE_URL.contains("demo") ? "demo" : matchingEnv
 } else {
-  matchingEnv = params.MANAGE_CASES_BASE_URL.contains("demo") ? "demo" : "aat"
+  matchingEnv = params.MANAGE_CASES_BASE_URL.contains("demo") ? "demo" : matchingEnv
 }
 
 def secrets = [

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -57,13 +57,12 @@ static Map < String, Object > secret(String secretName, String envVariable) {
   ]
 }
 
-def envSubstrings = ["aat", "demo", "preview"]
 def matchingEnv = "unknown"
 
 if(params.skipManageCasesTests) {
-  matchingEnv = envSubstrings.find{envSubstring -> params.CITIZEN_FRONTEND_BASE_URL.contains(envSubstring)}
+  matchingEnv = params.CITIZEN_FRONTEND_BASE_URL.contains("demo") ? "demo" : "aat"
 } else {
-  matchingEnv = envSubstrings.find{envSubstring -> params.MANAGE_CASES_BASE_URL.contains(envSubstring)}
+  matchingEnv = params.MANAGE_CASES_BASE_URL.contains("demo") ? "demo" : "aat"
 }
 
 def secrets = [


### PR DESCRIPTION
### Change description

Fix so that secrets are retrieved from AAT keyvault for preview environments 

Jenkins job successfully gets secrets for aat, preview and demo environments: https://build.hmcts.net/view/PRL/job/HMCTS_j_to_z/job/prl-e2e-tests/view/change-requests/job/PR-355/

**Before merging a pull request make sure that:**

- [x] Commits are meaningful and simple
- [x] All commits are squashed into a single commit
- [x] README and other documentation has been updated / added (if needed)
