### PR TITLE
Increase timeout for go button

### DIFF
--- a/e2e/common/helpers.ts
+++ b/e2e/common/helpers.ts
@@ -48,9 +48,9 @@ export class Helpers {
         },
         {
           // Allow 10s delay before retrying
-          intervals: [10_000],
-          // Allow up to a minute for it to disappear
-          timeout: 200_000,
+          intervals: [15_000],
+          // Allow up to 5 minutes for the go button to disappear
+          timeout: 300_000,
         },
       )
       .toBeFalsy();


### PR DESCRIPTION
a few tests are failing on the slow page loading after event selected from event dropdown, so increased the timeout for next page to load after "go" button is clicked

