### PR TITLE
fix: Fix applicant's family event spelling

### DIFF
--- a/e2e/common/types.ts
+++ b/e2e/common/types.ts
@@ -67,7 +67,7 @@ export type fl401SolicitorEvents =
   | "Respondent details"
   | "Other proceedings"
   | "Respondent's behaviour"
-  | "Applicant's family"
+  | "Applicant’s family"
   | "Relationship to respondent"
   | "Attending the hearing"
   | "The home"

--- a/e2e/journeys/manageCases/createCase/FL401ApplicantsFamily/FL401ApplicantsFamily.ts
+++ b/e2e/journeys/manageCases/createCase/FL401ApplicantsFamily/FL401ApplicantsFamily.ts
@@ -30,7 +30,7 @@ export class FL401ApplicantsFamily {
         errorMessaging: false,
       });
     }
-    await Helpers.handleEventBasedOnEnvironment(page, "Applicant's family");
+    await Helpers.handleEventBasedOnEnvironment(page, "Applicant’s family");
     await ApplicantsFamilyPage.applicantsFamilyPage(
       page,
       errorMessaging,


### PR DESCRIPTION
### Change description

- For some reason the event name uses a strange apostrophe that isn't standard

**Before merging a pull request make sure that:**

- [x] Commits are meaningful and simple
- [x] All commits are squashed into a single commit
- [x] README and other documentation has been updated / added (if needed)
