### PR TITLE
fix: Handle Applicant's family event naming issue

### DIFF
--- a/e2e/common/helpers.ts
+++ b/e2e/common/helpers.ts
@@ -31,7 +31,8 @@ export class Helpers {
       | WACaseWorkerActions
       | fl401CaseWorkerActions
       | courtAdminEvents
-      | amendEvents,
+      | amendEvents
+      | "Applicant’s family", // this is a temporary fix - the dropdown event needs to be renamed to match "Applicant's family"
   ): Promise<void> {
     await page.waitForLoadState("domcontentloaded");
     await page.waitForSelector("#next-step", { state: "visible" });
@@ -489,7 +490,12 @@ export class Helpers {
     ) {
       await Helpers.selectSolicitorEvent(page, event);
     } else if (process.env.MANAGE_CASES_TEST_ENV === "preview") {
-      await Helpers.chooseEventFromDropdown(page, event);
+      if (event === "Applicant's family") {
+        // this is a temporary fix - the dropdown event is spelt with a different apostrophe
+        await Helpers.chooseEventFromDropdown(page, "Applicant’s family");
+      } else {
+        await Helpers.chooseEventFromDropdown(page, event);
+      }
     } else {
       throw new Error(
         `Unexpected environment in URL: ${process.env.MANAGE_CASES_TEST_ENV}`,

--- a/e2e/common/types.ts
+++ b/e2e/common/types.ts
@@ -67,7 +67,7 @@ export type fl401SolicitorEvents =
   | "Respondent details"
   | "Other proceedings"
   | "Respondent's behaviour"
-  | "Applicant’s family"
+  | "Applicant's family"
   | "Relationship to respondent"
   | "Attending the hearing"
   | "The home"

--- a/e2e/journeys/manageCases/createCase/FL401ApplicantsFamily/FL401ApplicantsFamily.ts
+++ b/e2e/journeys/manageCases/createCase/FL401ApplicantsFamily/FL401ApplicantsFamily.ts
@@ -30,7 +30,7 @@ export class FL401ApplicantsFamily {
         errorMessaging: false,
       });
     }
-    await Helpers.handleEventBasedOnEnvironment(page, "Applicant’s family");
+    await Helpers.handleEventBasedOnEnvironment(page, "Applicant's family");
     await ApplicantsFamilyPage.applicantsFamilyPage(
       page,
       errorMessaging,


### PR DESCRIPTION


### Change description

- Handle event naming issue as the Applicant's family event uses a different apostrophe in the dropdown

**Before merging a pull request make sure that:**

- [x] Commits are meaningful and simple
- [x] All commits are squashed into a single commit
- [x] README and other documentation has been updated / added (if needed)
