### PR TITLE
fix: Add fixes for links that were missed from previous SRT

### DIFF
--- a/e2e/pages/manageCases/caseTabs/C100/c100CaseDocumentsTabPage.ts
+++ b/e2e/pages/manageCases/caseTabs/C100/c100CaseDocumentsTabPage.ts
@@ -1,5 +1,6 @@
 import { expect, Page } from "@playwright/test";
 import { C100CaseDocumentsTabContent } from "../../../../fixtures/manageCases/caseTabs/C100/c100CaseDocumentsTabContent.js";
+import { Selectors } from "../../../../common/selectors.js";
 
 export class C100CaseDocumentsTabPage {
   public static async c100CaseDocumentsTabPageManageDocuments(
@@ -33,7 +34,7 @@ export class C100CaseDocumentsTabPage {
       ).toBeVisible(),
       expect(
         page
-          .getByRole("link")
+          .locator(Selectors.GovLink)
           .filter({ hasText: C100CaseDocumentsTabContent.link }),
       ).toBeVisible(),
       expect(

--- a/e2e/pages/manageCases/caseTabs/C100/c100ConfidentialDetailsTabPage.ts
+++ b/e2e/pages/manageCases/caseTabs/C100/c100ConfidentialDetailsTabPage.ts
@@ -237,7 +237,7 @@ export class C100ConfidentialDetailsTabPage {
             .getByRole("cell", {
               name: `${C100ConfidentialDetailsTabContent.refugeSectionDocument} ${C100ConfidentialDetailsTabContent.testPdf} Uploaded by`,
             })
-            .getByRole("link")
+            .locator(Selectors.GovLink)
             .filter({ hasText: C100ConfidentialDetailsTabContent.testPdf }),
         ).toBeVisible(),
         expect(

--- a/e2e/pages/manageCases/caseTabs/FL401/fl401CaseDocumentsTabPage.ts
+++ b/e2e/pages/manageCases/caseTabs/FL401/fl401CaseDocumentsTabPage.ts
@@ -1,5 +1,6 @@
 import { expect, Page } from "@playwright/test";
 import { FL401CaseDocumentsTabContent } from "../../../../fixtures/manageCases/caseTabs/FL401/fl401CaseDocumentsTabContent.js";
+import { Selectors } from "../../../../common/selectors.js";
 
 export class Fl401CaseDocumentsTabPage {
   public static async fl401CaseDocumentsTabPageManageDocuments(
@@ -33,7 +34,7 @@ export class Fl401CaseDocumentsTabPage {
       ).toBeVisible(),
       expect(
         page
-          .getByRole("link")
+          .locator(Selectors.GovLink)
           .filter({ hasText: FL401CaseDocumentsTabContent.link }),
       ).toBeVisible(),
       expect(

--- a/e2e/pages/manageCases/caseTabs/FL401/fl401ConfidentialDetailsTabPage.ts
+++ b/e2e/pages/manageCases/caseTabs/FL401/fl401ConfidentialDetailsTabPage.ts
@@ -223,7 +223,7 @@ export class FL401ConfidentialDetailsTabPage {
             .getByRole("cell", {
               name: `${FL401ConfidentialDetailsTabContent.refugeSectionDocument} ${FL401ConfidentialDetailsTabContent.testPdf} Uploaded by`,
             })
-            .getByRole("link")
+            .locator(Selectors.GovLink)
             .filter({ hasText: FL401ConfidentialDetailsTabContent.testPdf }),
         ).toBeVisible(),
         expect(


### PR DESCRIPTION
### Change description

- Change expected links to gov link selectors which were introduced after an SRT but were missed on these tests
- Manage Documents tests passing on Jenkins nightly-dev: https://build.hmcts.net/view/PRL/job/HMCTS_j_to_z_Nightly/job/prl-e2e-tests/job/nightly-dev/72/

**Before merging a pull request make sure that:**

- [x] Commits are meaningful and simple
- [x] All commits are squashed into a single commit
- [x] README and other documentation has been updated / added (if needed)
